### PR TITLE
Added authentication & authorization using access token (JsonWebToken)

### DIFF
--- a/src/main/java/ru/dreadblade/czarbank/api/controller/BankAccountController.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/controller/BankAccountController.java
@@ -9,7 +9,6 @@ import ru.dreadblade.czarbank.api.model.request.BankAccountRequestDTO;
 import ru.dreadblade.czarbank.api.model.response.BankAccountResponseDTO;
 import ru.dreadblade.czarbank.domain.BankAccount;
 import ru.dreadblade.czarbank.service.BankAccountService;
-
 import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.util.List;
@@ -28,7 +27,7 @@ public class BankAccountController {
     }
 
     @GetMapping
-    public ResponseEntity<List<BankAccountResponseDTO>> findAllAll() {
+    public ResponseEntity<List<BankAccountResponseDTO>> findAll() {
         return ResponseEntity.ok(bankAccountService.findAll().stream()
                 .map(bankAccountMapper::bankAccountToBankAccountResponse)
                 .collect(Collectors.toList()));

--- a/src/main/java/ru/dreadblade/czarbank/api/controller/security/AuthenticationController.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/controller/security/AuthenticationController.java
@@ -1,0 +1,32 @@
+package ru.dreadblade.czarbank.api.controller.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import ru.dreadblade.czarbank.api.model.request.security.AuthenticationRequestDTO;
+import ru.dreadblade.czarbank.api.model.response.security.AuthenticationResponseDTO;
+import ru.dreadblade.czarbank.domain.security.User;
+import ru.dreadblade.czarbank.security.service.AuthenticationService;
+
+@RequestMapping("/api/auth")
+@RestController
+public class AuthenticationController {
+    private final AuthenticationService authenticationService;
+
+    @Autowired
+    public AuthenticationController(AuthenticationService authenticationService) {
+        this.authenticationService = authenticationService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthenticationResponseDTO> login(@RequestBody AuthenticationRequestDTO authenticationRequestDTO) {
+        User authenticatedUser = authenticationService.authenticateUser(authenticationRequestDTO);
+
+        return ResponseEntity.ok(AuthenticationResponseDTO.builder()
+                .accessToken(authenticationService.getAccessToken(authenticatedUser))
+                .build());
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/api/model/request/security/AuthenticationRequestDTO.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/model/request/security/AuthenticationRequestDTO.java
@@ -1,0 +1,13 @@
+package ru.dreadblade.czarbank.api.model.request.security;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthenticationRequestDTO {
+    private String username;
+    private String password;
+}

--- a/src/main/java/ru/dreadblade/czarbank/api/model/response/security/AuthenticationResponseDTO.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/model/response/security/AuthenticationResponseDTO.java
@@ -1,0 +1,12 @@
+package ru.dreadblade.czarbank.api.model.response.security;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthenticationResponseDTO {
+    private String accessToken;
+}

--- a/src/main/java/ru/dreadblade/czarbank/domain/security/User.java
+++ b/src/main/java/ru/dreadblade/czarbank/domain/security/User.java
@@ -1,9 +1,14 @@
 package ru.dreadblade.czarbank.domain.security;
 
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import javax.persistence.*;
+import java.util.Collection;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -12,7 +17,7 @@ import java.util.Set;
 @AllArgsConstructor
 @Entity
 @Table(name = "users")
-public class User {
+public class User implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
@@ -31,4 +36,44 @@ public class User {
             joinColumns = { @JoinColumn(name = "USER_ID", referencedColumnName = "ID") },
             inverseJoinColumns = { @JoinColumn(name = "ROLE_ID", referencedColumnName = "ID" ) })
     private Set<Role> roles;
+
+    private boolean isAccountExpired;
+    private boolean isAccountLocked;
+    private boolean isCredentialsExpired;
+    private boolean isEnabled;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Set<SimpleGrantedAuthority> authorities = roles.stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role.getName()))
+                .collect(Collectors.toSet());
+
+        authorities.addAll(roles.stream()
+                .map(Role::getPermissions)
+                .flatMap(Set::stream)
+                .map(permission -> new SimpleGrantedAuthority(permission.getName()))
+                .collect(Collectors.toSet()));
+
+        return authorities;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return !isAccountExpired;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return !isAccountLocked;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return !isCredentialsExpired;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return isEnabled;
+    }
 }

--- a/src/main/java/ru/dreadblade/czarbank/domain/security/User.java
+++ b/src/main/java/ru/dreadblade/czarbank/domain/security/User.java
@@ -37,10 +37,17 @@ public class User implements UserDetails {
             inverseJoinColumns = { @JoinColumn(name = "ROLE_ID", referencedColumnName = "ID" ) })
     private Set<Role> roles;
 
-    private boolean isAccountExpired;
-    private boolean isAccountLocked;
-    private boolean isCredentialsExpired;
-    private boolean isEnabled;
+    @Builder.Default
+    private boolean isAccountExpired = false;
+
+    @Builder.Default
+    private boolean isAccountLocked = false;
+
+    @Builder.Default
+    private boolean isCredentialsExpired = false;
+
+    @Builder.Default
+    private boolean isEnabled = true;
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/ru/dreadblade/czarbank/exception/handler/AccessTokenExceptionHandler.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/handler/AccessTokenExceptionHandler.java
@@ -1,0 +1,35 @@
+package ru.dreadblade.czarbank.exception.handler;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import ru.dreadblade.czarbank.exception.model.ErrorResponse;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestControllerAdvice
+public class AccessTokenExceptionHandler {
+
+    @ExceptionHandler(TokenExpiredException.class)
+    public ResponseEntity<ErrorResponse> handleJsonWebTokenExpiredException(TokenExpiredException exception, HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED.value()).body(ErrorResponse.builder()
+                .status(HttpStatus.UNAUTHORIZED.value())
+                .error(HttpStatus.UNAUTHORIZED.getReasonPhrase())
+                .message("Access token expired")
+                .path(request.getRequestURI())
+                .build());
+    }
+
+    @ExceptionHandler(JWTVerificationException.class)
+    public ResponseEntity<ErrorResponse> handleJsonWebTokenVerificationException(JWTVerificationException exception, HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED.value()).body(ErrorResponse.builder()
+                .status(HttpStatus.UNAUTHORIZED.value())
+                .error(HttpStatus.UNAUTHORIZED.getReasonPhrase())
+                .message("Access token is invalid")
+                .path(request.getRequestURI())
+                .build());
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/exception/handler/AuthenticationExceptionHandler.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/handler/AuthenticationExceptionHandler.java
@@ -1,0 +1,23 @@
+package ru.dreadblade.czarbank.exception.handler;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import ru.dreadblade.czarbank.exception.model.ErrorResponse;
+
+import javax.servlet.http.HttpServletRequest;
+
+@RestControllerAdvice
+public class AuthenticationExceptionHandler {
+    @ExceptionHandler(BadCredentialsException.class)
+    public ResponseEntity<ErrorResponse> handleBadCredentialsException(BadCredentialsException exception, HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED.value()).body(ErrorResponse.builder()
+                .status(HttpStatus.UNAUTHORIZED.value())
+                .error(HttpStatus.UNAUTHORIZED.getReasonPhrase())
+                .message("Invalid username and/or password")
+                .path(request.getRequestURI())
+                .build());
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/exception/handler/AuthenticationExceptionHandler.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/handler/AuthenticationExceptionHandler.java
@@ -2,6 +2,7 @@ package ru.dreadblade.czarbank.exception.handler;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AccountStatusException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -17,6 +18,16 @@ public class AuthenticationExceptionHandler {
                 .status(HttpStatus.UNAUTHORIZED.value())
                 .error(HttpStatus.UNAUTHORIZED.getReasonPhrase())
                 .message("Invalid username and/or password")
+                .path(request.getRequestURI())
+                .build());
+    }
+
+    @ExceptionHandler(AccountStatusException.class)
+    public ResponseEntity<ErrorResponse> handleAccountStatusException(AccountStatusException exception, HttpServletRequest request) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED.value()).body(ErrorResponse.builder()
+                .status(HttpStatus.UNAUTHORIZED.value())
+                .error(HttpStatus.UNAUTHORIZED.getReasonPhrase())
+                .message(exception.getMessage())
                 .path(request.getRequestURI())
                 .build());
     }

--- a/src/main/java/ru/dreadblade/czarbank/exception/handler/BaseExceptionHandler.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/handler/BaseExceptionHandler.java
@@ -11,6 +11,7 @@ import javax.servlet.http.HttpServletRequest;
 
 @RestControllerAdvice
 public class BaseExceptionHandler {
+
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ErrorResponse> handleBankAccountNotFoundException(BaseException exception, HttpServletRequest request) {
         return ExceptionHandlingUtils.createErrorResponse(exception, request);

--- a/src/main/java/ru/dreadblade/czarbank/security/config/EncryptionConfiguration.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/config/EncryptionConfiguration.java
@@ -1,0 +1,14 @@
+package ru.dreadblade.czarbank.security.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class EncryptionConfiguration {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return NoOpPasswordEncoder.getInstance();
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/security/config/SecurityConfiguration.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/config/SecurityConfiguration.java
@@ -1,21 +1,47 @@
 package ru.dreadblade.czarbank.security.config;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import ru.dreadblade.czarbank.security.exception.FilterChainExceptionHandler;
+import ru.dreadblade.czarbank.security.filter.JsonWebTokenAuthorizationFilter;
 
 @Configuration
 @EnableWebSecurity
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+    private final JsonWebTokenAuthorizationFilter authorizationFilter;
+    private final FilterChainExceptionHandler filterChainExceptionHandler;
+
+    @Autowired
+    public SecurityConfiguration(JsonWebTokenAuthorizationFilter authorizationFilter, FilterChainExceptionHandler filterChainExceptionHandler) {
+        this.authorizationFilter = authorizationFilter;
+        this.filterChainExceptionHandler = filterChainExceptionHandler;
+    }
+
     @Override
     protected void configure(HttpSecurity http) throws Exception {
-        http.csrf()
-                .ignoringAntMatchers("/api/**")
+        http
+                .addFilterBefore(authorizationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(filterChainExceptionHandler, JsonWebTokenAuthorizationFilter.class)
+                .csrf().ignoringAntMatchers("/api/**")
                 .and()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
-                .httpBasic().disable();
+                .httpBasic().disable()
+                .formLogin().disable();
+    }
+
+    @Bean
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
     }
 }

--- a/src/main/java/ru/dreadblade/czarbank/security/exception/FilterChainExceptionHandler.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/exception/FilterChainExceptionHandler.java
@@ -3,6 +3,7 @@ package ru.dreadblade.czarbank.security.exception;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.authentication.AccountStatusException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.servlet.HandlerExceptionResolver;
@@ -26,7 +27,7 @@ public class FilterChainExceptionHandler extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         try {
             filterChain.doFilter(request, response);
-        } catch (JWTVerificationException e) {
+        } catch (JWTVerificationException | AccountStatusException e) {
             resolver.resolveException(request, response, null, e);
         }
     }

--- a/src/main/java/ru/dreadblade/czarbank/security/exception/FilterChainExceptionHandler.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/exception/FilterChainExceptionHandler.java
@@ -1,0 +1,33 @@
+package ru.dreadblade.czarbank.security.exception;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class FilterChainExceptionHandler extends OncePerRequestFilter {
+    private final HandlerExceptionResolver resolver;
+
+    @Autowired
+    public FilterChainExceptionHandler(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } catch (JWTVerificationException e) {
+            resolver.resolveException(request, response, null, e);
+        }
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/security/exception/RestAuthenticationEntryPoint.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/exception/RestAuthenticationEntryPoint.java
@@ -1,0 +1,28 @@
+package ru.dreadblade.czarbank.security.exception;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final HandlerExceptionResolver resolver;
+
+    @Autowired
+    public RestAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+        this.resolver = resolver;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        resolver.resolveException(request, response, null, authException);
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/security/filter/JsonWebTokenAuthorizationFilter.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/filter/JsonWebTokenAuthorizationFilter.java
@@ -1,0 +1,58 @@
+package ru.dreadblade.czarbank.security.filter;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import ru.dreadblade.czarbank.domain.security.User;
+import ru.dreadblade.czarbank.security.service.AccessTokenService;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JsonWebTokenAuthorizationFilter extends OncePerRequestFilter {
+    @Value("${czar-bank.security.json-web-token.access-token.header.prefix}")
+    private String headerPrefix;
+
+    private final AccessTokenService accessTokenService;
+
+    @Autowired
+    public JsonWebTokenAuthorizationFilter(AccessTokenService accessTokenService) {
+        this.accessTokenService = accessTokenService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (request.getServletPath().equals("/api/auth")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+
+        if (StringUtils.isBlank(accessToken) || !accessToken.startsWith(headerPrefix)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        accessToken = accessToken.substring(headerPrefix.length());
+
+        User user = accessTokenService.getUserFromToken(accessToken);
+
+        var token = new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+        token.setDetails(new WebAuthenticationDetails(request));
+
+        SecurityContextHolder.getContext().setAuthentication(token);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/security/service/AccessTokenService.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/service/AccessTokenService.java
@@ -1,0 +1,68 @@
+package ru.dreadblade.czarbank.security.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.JWTVerifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.stereotype.Service;
+import ru.dreadblade.czarbank.domain.security.User;
+import ru.dreadblade.czarbank.exception.EntityNotFoundException;
+import ru.dreadblade.czarbank.exception.ExceptionMessage;
+import ru.dreadblade.czarbank.repository.security.UserRepository;
+
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class AccessTokenService {
+    @Value("${czar-bank.security.json-web-token.access-token.issuer}")
+    private String issuer;
+
+    @Value("${czar-bank.security.json-web-token.access-token.audience}")
+    private String audience;
+
+    @Value("${czar-bank.security.json-web-token.access-token.expiration-seconds}")
+    private int expirationSeconds;
+
+    private String secretKey;
+
+    private final UserRepository userRepository;
+    private final JWTVerifier verifier;
+
+    public AccessTokenService(@Value("${czar-bank.security.json-web-token.access-token.secret-key}") String secretKey,
+                              UserRepository userRepository) {
+        this.userRepository = userRepository;
+        this.secretKey = secretKey;
+        this.verifier = JWT.require(Algorithm.HMAC512(secretKey)).build();
+    }
+
+    public String generateAccessToken(User user) {
+        List<String> authorities = user.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.toList());
+
+        Date issuedAt = new Date();
+        Date expiresAt = new Date(System.currentTimeMillis() + expirationSeconds * 1000L);
+
+        return JWT.create()
+                .withIssuer(issuer)
+                .withAudience(audience)
+                .withSubject(user.getUsername())
+                .withIssuedAt(issuedAt)
+                .withExpiresAt(expiresAt)
+                .withClaim("authorities", authorities)
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    public User getUserFromToken(String accessToken) {
+        DecodedJWT decodedJWT = verifier.verify(accessToken);
+
+        String username = decodedJWT.getSubject();
+
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/security/service/AuthenticationService.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/service/AuthenticationService.java
@@ -1,0 +1,44 @@
+package ru.dreadblade.czarbank.security.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import ru.dreadblade.czarbank.api.model.request.security.AuthenticationRequestDTO;
+import ru.dreadblade.czarbank.domain.security.User;
+import ru.dreadblade.czarbank.exception.EntityNotFoundException;
+import ru.dreadblade.czarbank.exception.ExceptionMessage;
+
+@Service
+public class AuthenticationService {
+    private final AccessTokenService accessTokenService;
+    private final AuthenticationManager authenticationManager;
+
+    @Autowired
+    public AuthenticationService(AccessTokenService accessTokenService, AuthenticationManager authenticationManager) {
+        this.accessTokenService = accessTokenService;
+        this.authenticationManager = authenticationManager;
+    }
+
+    public User authenticateUser(AuthenticationRequestDTO authenticationRequestDTO) {
+        String username = authenticationRequestDTO.getUsername();
+        String password = authenticationRequestDTO.getPassword();
+
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(username, password);
+
+        Authentication authentication = authenticationManager.authenticate(token);
+
+        Object principal = authentication.getPrincipal();
+
+        if (principal instanceof User) {
+            return (User) principal;
+        }
+
+        throw new EntityNotFoundException(ExceptionMessage.USER_NOT_FOUND);
+    }
+
+    public String getAccessToken(User user) {
+        return accessTokenService.generateAccessToken(user);
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/security/service/CustomUserDetailsService.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/service/CustomUserDetailsService.java
@@ -1,0 +1,24 @@
+package ru.dreadblade.czarbank.security.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import ru.dreadblade.czarbank.repository.security.UserRepository;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    @Autowired
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User with username \"" + username + "\" not found"));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,3 +6,14 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+
+czar-bank:
+  security:
+    json-web-token:
+      access-token:
+        issuer: 'Czar Bank'
+        audience: 'Czar Bank clients and staff'
+        expiration-seconds: 900
+        secret-key: 'czar-bank-secret-key'
+        header:
+          prefix: 'Bearer '

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/AuthenticationIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/AuthenticationIntegrationTest.java
@@ -1,0 +1,161 @@
+package ru.dreadblade.czarbank.api.controller;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import ru.dreadblade.czarbank.api.model.request.security.AuthenticationRequestDTO;
+import ru.dreadblade.czarbank.api.model.response.security.AuthenticationResponseDTO;
+import ru.dreadblade.czarbank.domain.security.User;
+import ru.dreadblade.czarbank.repository.security.UserRepository;
+import ru.dreadblade.czarbank.security.service.AccessTokenService;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers.authenticated;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(properties = { "czar-bank.security.json-web-token.access-token.expiration-seconds=5"})
+@DisplayName("Authentication Integration Tests")
+@Sql(value = "/user/users-insertion.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(value = "/user/users-deletion.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+public class AuthenticationIntegrationTest extends BaseIntegrationTest {
+
+    private static final String LOGIN_API_URL = "/api/auth/login";
+    private static final String USERS_API_URL = "/api/users";
+    private static final String ACCESS_TOKEN_IS_INVALID_MESSAGE = "Access token is invalid";
+    private static final String ACCESS_TOKEN_EXPIRED_MESSAGE = "Access token expired";
+
+    @Value("${czar-bank.security.json-web-token.access-token.header.prefix}")
+    private String headerPrefix;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    AccessTokenService accessTokenService;
+
+    @Nested
+    @DisplayName("login() Tests")
+    class loginTests {
+        @ParameterizedTest(name = "#{index} with [{arguments}]")
+        @MethodSource("ru.dreadblade.czarbank.api.controller.AuthenticationIntegrationTest#getStreamAllUsers")
+        void login_isSuccessful(String username, String password) throws Exception {
+            AuthenticationRequestDTO authenticationRequestDTO = AuthenticationRequestDTO.builder()
+                    .username(username)
+                    .password(password)
+                    .build();
+
+            String requestContent = objectMapper.writeValueAsString(authenticationRequestDTO);
+
+            String responseContent = mockMvc.perform(post(LOGIN_API_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestContent))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.accessToken").isString())
+                    .andReturn()
+                    .getResponse()
+                    .getContentAsString();
+
+            String accessToken = objectMapper.readValue(responseContent, AuthenticationResponseDTO.class)
+                    .getAccessToken();
+
+            User userFromToken = accessTokenService.getUserFromToken(accessToken);
+
+            Assertions.assertThat(userFromToken.getUsername()).isEqualTo(username);
+        }
+
+        @Test
+        void login_isBadCredentials() throws Exception {
+            AuthenticationRequestDTO authenticationRequestDTO = AuthenticationRequestDTO.builder()
+                    .username("someUser")
+                    .password("somePass")
+                    .build();
+
+            String requestContent = objectMapper.writeValueAsString(authenticationRequestDTO);
+
+            mockMvc.perform(post(LOGIN_API_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestContent))
+                    .andExpect(status().isUnauthorized());
+        }
+    }
+
+    @Nested
+    @DisplayName("Access Token Tests")
+    class accessTokenTests {
+
+        /**
+         * Disabled due to https://github.com/spring-projects/spring-security/issues/4516
+         */
+        @Disabled
+        @ParameterizedTest(name = "#{index} with [{arguments}]")
+        @MethodSource("ru.dreadblade.czarbank.api.controller.AuthenticationIntegrationTest#getStreamAllUsers")
+        void accessToken_isValid(String username) throws Exception {
+            User user = userRepository.findByUsername(username).orElseThrow();
+
+            String accessToken = headerPrefix + accessTokenService.generateAccessToken(user);
+
+            mockMvc.perform(get(USERS_API_URL)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken))
+                    .andExpect(authenticated());
+        }
+
+        @ParameterizedTest(name = "#{index} with [{arguments}]")
+        @MethodSource("ru.dreadblade.czarbank.api.controller.AuthenticationIntegrationTest#getStreamAllUsers")
+        void accessToken_withInvalidSignature_isFailed(String username) throws Exception {
+            User user = userRepository.findByUsername(username).orElseThrow();
+
+            String accessToken = headerPrefix + accessTokenService.generateAccessToken(user) + "someCorruption...";
+
+            mockMvc.perform(get(USERS_API_URL)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_IS_INVALID_MESSAGE));
+        }
+
+        @ParameterizedTest(name = "#{index} with [{arguments}]")
+        @MethodSource("ru.dreadblade.czarbank.api.controller.AuthenticationIntegrationTest#getStreamAllUsers")
+        void accessToken_modified_isFailed(String username) throws Exception {
+            User user = userRepository.findByUsername(username).orElseThrow();
+
+            String accessTokenBeforeCorruption = accessTokenService.generateAccessToken(user);
+
+            int cut = 20;
+
+            String accessToken = headerPrefix + accessTokenBeforeCorruption.substring(0, cut) + "some data..." +
+                    accessTokenBeforeCorruption.substring(cut);
+
+            mockMvc.perform(get(USERS_API_URL)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_IS_INVALID_MESSAGE));
+        }
+
+        @Test
+        void accessToken_isExpired_isFailed() throws Exception {
+            User user = userRepository.findById(BASE_USER_ID + 1L).orElseThrow();
+
+            String accessToken = headerPrefix + accessTokenService.generateAccessToken(user);
+
+            TimeUnit.SECONDS.sleep(6);
+
+            mockMvc.perform(get(USERS_API_URL)
+                    .header(HttpHeaders.AUTHORIZATION, accessToken))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.message").value(ACCESS_TOKEN_EXPIRED_MESSAGE));
+        }
+    }
+}

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/BaseIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/BaseIntegrationTest.java
@@ -3,6 +3,7 @@ package ru.dreadblade.czarbank.api.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,7 +17,10 @@ import org.springframework.web.context.WebApplicationContext;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
+import java.util.stream.Stream;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
 
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @ContextConfiguration(initializers = BaseIntegrationTest.DockerPostgreDataSourceInitializer.class)
@@ -49,6 +53,7 @@ public abstract class BaseIntegrationTest {
     public void setUp() {
         mockMvc = MockMvcBuilders
                 .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
                 .build();
     }
 
@@ -57,6 +62,12 @@ public abstract class BaseIntegrationTest {
         assertThat(webApplicationContext).isNotNull();
         assertThat(mockMvc).isNotNull();
         assertThat(objectMapper).isNotNull();
+    }
+
+    public static Stream<Arguments> getStreamAllUsers() {
+        return Stream.of(Arguments.of("admin", "password"),
+                Arguments.of("employee", "password"),
+                Arguments.of("client", "password"));
     }
 
     public static PostgreSQLContainer<?> postgresqlContainer = new PostgreSQLContainer<>("postgres:13")

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,3 +4,14 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+
+czar-bank:
+  security:
+    json-web-token:
+      access-token:
+        issuer: 'Czar Bank'
+        audience: 'Czar Bank clients and staff'
+        expiration-seconds: 900
+        secret-key: 'czar-bank-secret-key'
+        header:
+          prefix: 'Bearer '

--- a/src/test/resources/user/users-insertion.sql
+++ b/src/test/resources/user/users-insertion.sql
@@ -29,12 +29,12 @@ values (13, 1), (13, 2), (13, 3), (13, 4), (13, 5), (13, 6), (13, 7), (13, 8), (
 insert into role_permission (role_id, permission_id)
 values (14, 5), (14, 6), (14, 7), (14, 8), (14, 9), (14, 10), (14, 11), (14, 12);
 
-insert into users (id, user_id, username, email, password) values (16, '1234567890', 'admin', 'admin@czarbank.org', 'password');
-insert into users (id, user_id, username, email, password) values (17, '0192837465', 'employee', 'employee@czarbank.org', 'password');
-insert into users (id, user_id, username, email, password) values (18, '6574832910', 'client', 'client@czarbank.org', 'password');
-insert into users (id, user_id, username, email, password) values (19, '0659483721', 'unused', 'unused@czarbank.org', 'password');
+insert into users (id, user_id, username, email, password, is_account_expired, is_account_locked, is_credentials_expired, is_enabled) values
+(16, '1234567890', 'admin', 'admin@czarbank.org', 'password', false, false, false, true),
+(17, '0192837465', 'employee', 'employee@czarbank.org', 'password', false, false, false, true),
+(18, '6574832910', 'client', 'client@czarbank.org', 'password', false, false, false, true),
+(19, '0659483721', 'unused', 'unused@czarbank.org', 'password', false, false, false, true);
 
-insert into user_role (user_id, role_id)
-values (16, 13), (17, 14), (18, 15);
+insert into user_role (user_id, role_id) values (16, 13), (17, 14), (18, 15);
 
 alter sequence hibernate_sequence restart 20;


### PR DESCRIPTION
Added a new API endpoint for authentication: `/api/auth/login`
For authentication, you need to send a username and password in the request body.
Authorization requires an access token in the authorization header and a `Bearer `  prefix before access token (except `/api/auth/**`)