### PR TITLE
Added token refreshing functionality via refresh tokens

### DIFF
--- a/src/main/java/ru/dreadblade/czarbank/api/controller/security/AuthenticationController.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/controller/security/AuthenticationController.java
@@ -7,26 +7,47 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import ru.dreadblade.czarbank.api.model.request.security.AuthenticationRequestDTO;
+import ru.dreadblade.czarbank.api.model.request.security.RefreshTokensRequestDTO;
 import ru.dreadblade.czarbank.api.model.response.security.AuthenticationResponseDTO;
 import ru.dreadblade.czarbank.domain.security.User;
+import ru.dreadblade.czarbank.security.service.AccessTokenService;
 import ru.dreadblade.czarbank.security.service.AuthenticationService;
+import ru.dreadblade.czarbank.security.service.RefreshTokenService;
 
 @RequestMapping("/api/auth")
 @RestController
 public class AuthenticationController {
     private final AuthenticationService authenticationService;
+    private final AccessTokenService accessTokenService;
+    private final RefreshTokenService refreshTokenService;
 
     @Autowired
-    public AuthenticationController(AuthenticationService authenticationService) {
+    public AuthenticationController(AuthenticationService authenticationService, AccessTokenService accessTokenService, RefreshTokenService refreshTokenService) {
         this.authenticationService = authenticationService;
+        this.accessTokenService = accessTokenService;
+        this.refreshTokenService = refreshTokenService;
     }
 
     @PostMapping("/login")
     public ResponseEntity<AuthenticationResponseDTO> login(@RequestBody AuthenticationRequestDTO authenticationRequestDTO) {
         User authenticatedUser = authenticationService.authenticateUser(authenticationRequestDTO);
 
+        String accessToken = accessTokenService.generateAccessToken(authenticatedUser);
+        String refreshToken = refreshTokenService.generateRefreshToken(authenticatedUser);
+
         return ResponseEntity.ok(AuthenticationResponseDTO.builder()
-                .accessToken(authenticationService.getAccessToken(authenticatedUser))
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build());
+    }
+
+    @PostMapping("/refresh-tokens")
+    public ResponseEntity<AuthenticationResponseDTO> refreshTokens(@RequestBody RefreshTokensRequestDTO refreshTokensRequestDTO) {
+        String refreshToken = refreshTokensRequestDTO.getRefreshToken();
+
+        return ResponseEntity.ok(AuthenticationResponseDTO.builder()
+                .accessToken(refreshTokenService.updateAccessToken(refreshToken))
+                .refreshToken(refreshTokenService.updateRefreshToken(refreshToken))
                 .build());
     }
 }

--- a/src/main/java/ru/dreadblade/czarbank/api/model/request/security/RefreshTokensRequestDTO.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/model/request/security/RefreshTokensRequestDTO.java
@@ -1,0 +1,12 @@
+package ru.dreadblade.czarbank.api.model.request.security;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshTokensRequestDTO {
+    private String refreshToken;
+}

--- a/src/main/java/ru/dreadblade/czarbank/api/model/response/security/AuthenticationResponseDTO.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/model/response/security/AuthenticationResponseDTO.java
@@ -9,4 +9,5 @@ import lombok.*;
 @AllArgsConstructor
 public class AuthenticationResponseDTO {
     private String accessToken;
+    private String refreshToken;
 }

--- a/src/main/java/ru/dreadblade/czarbank/domain/security/RefreshTokenSession.java
+++ b/src/main/java/ru/dreadblade/czarbank/domain/security/RefreshTokenSession.java
@@ -1,0 +1,32 @@
+package ru.dreadblade.czarbank.domain.security;
+
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.time.Instant;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class RefreshTokenSession {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(updatable = false, unique = true)
+    private String refreshToken;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    private User user;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private Instant createdAt;
+
+    @Builder.Default
+    private Boolean isRevoked = false;
+}

--- a/src/main/java/ru/dreadblade/czarbank/exception/BaseAuthenticationException.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/BaseAuthenticationException.java
@@ -1,0 +1,7 @@
+package ru.dreadblade.czarbank.exception;
+
+public abstract class BaseAuthenticationException extends BaseException {
+    public BaseAuthenticationException(ExceptionMessage exceptionMessage) {
+        super(exceptionMessage.getMessage(), exceptionMessage.getStatus());
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
@@ -18,7 +18,10 @@ public enum ExceptionMessage {
 
     BANK_ACCOUNT_TYPE_IN_USE("Bank account type in use", HttpStatus.BAD_REQUEST),
 
-    NOT_ENOUGH_BALANCE("Not enough balance", HttpStatus.BAD_REQUEST);
+    NOT_ENOUGH_BALANCE("Not enough balance", HttpStatus.BAD_REQUEST),
+
+    REFRESH_TOKEN_EXPIRED("Refresh token expired", HttpStatus.BAD_REQUEST),
+    INVALID_REFRESH_TOKEN("Invalid refresh token", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/ru/dreadblade/czarbank/exception/RefreshTokenException.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/RefreshTokenException.java
@@ -1,0 +1,7 @@
+package ru.dreadblade.czarbank.exception;
+
+public class RefreshTokenException extends BaseAuthenticationException {
+    public RefreshTokenException(ExceptionMessage exceptionMessage) {
+        super(exceptionMessage);
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/exception/handler/AuthenticationExceptionHandler.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/handler/AuthenticationExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.security.authentication.AccountStatusException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import ru.dreadblade.czarbank.exception.RefreshTokenException;
 import ru.dreadblade.czarbank.exception.model.ErrorResponse;
 
 import javax.servlet.http.HttpServletRequest;
@@ -27,6 +28,16 @@ public class AuthenticationExceptionHandler {
         return ResponseEntity.status(HttpStatus.UNAUTHORIZED.value()).body(ErrorResponse.builder()
                 .status(HttpStatus.UNAUTHORIZED.value())
                 .error(HttpStatus.UNAUTHORIZED.getReasonPhrase())
+                .message(exception.getMessage())
+                .path(request.getRequestURI())
+                .build());
+    }
+
+    @ExceptionHandler(RefreshTokenException.class)
+    public ResponseEntity<ErrorResponse> handleTokenExpiredException(RefreshTokenException exception, HttpServletRequest request) {
+        return ResponseEntity.status(exception.getStatus()).body(ErrorResponse.builder()
+                .status(exception.getStatus().value())
+                .error(exception.getStatus().getReasonPhrase())
                 .message(exception.getMessage())
                 .path(request.getRequestURI())
                 .build());

--- a/src/main/java/ru/dreadblade/czarbank/exception/handler/BaseExceptionHandler.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/handler/BaseExceptionHandler.java
@@ -13,7 +13,7 @@ import javax.servlet.http.HttpServletRequest;
 public class BaseExceptionHandler {
 
     @ExceptionHandler(BaseException.class)
-    public ResponseEntity<ErrorResponse> handleBankAccountNotFoundException(BaseException exception, HttpServletRequest request) {
+    public ResponseEntity<ErrorResponse> handleBaseException(BaseException exception, HttpServletRequest request) {
         return ExceptionHandlingUtils.createErrorResponse(exception, request);
     }
 }

--- a/src/main/java/ru/dreadblade/czarbank/repository/security/RefreshTokenSessionRepository.java
+++ b/src/main/java/ru/dreadblade/czarbank/repository/security/RefreshTokenSessionRepository.java
@@ -1,12 +1,23 @@
 package ru.dreadblade.czarbank.repository.security;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import ru.dreadblade.czarbank.domain.security.RefreshTokenSession;
+import ru.dreadblade.czarbank.domain.security.User;
 
 import java.util.Optional;
 
 public interface RefreshTokenSessionRepository extends JpaRepository<RefreshTokenSession, Long> {
     Optional<RefreshTokenSession> findByRefreshToken(String refreshToken);
 
+    @Query("select count(r) from RefreshTokenSession as r where r.isRevoked = false and r.user.id = :#{#user.id}")
+    Long countByUser(@Param("user") User user);
+
     boolean existsByRefreshToken(String refreshToken);
+
+    @Modifying
+    @Query("update RefreshTokenSession as r set r.isRevoked = true where r.user.id = :#{#user.id}")
+    void markRevokedAllByUser(@Param("user") User user);
 }

--- a/src/main/java/ru/dreadblade/czarbank/repository/security/RefreshTokenSessionRepository.java
+++ b/src/main/java/ru/dreadblade/czarbank/repository/security/RefreshTokenSessionRepository.java
@@ -1,0 +1,12 @@
+package ru.dreadblade.czarbank.repository.security;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ru.dreadblade.czarbank.domain.security.RefreshTokenSession;
+
+import java.util.Optional;
+
+public interface RefreshTokenSessionRepository extends JpaRepository<RefreshTokenSession, Long> {
+    Optional<RefreshTokenSession> findByRefreshToken(String refreshToken);
+
+    boolean existsByRefreshToken(String refreshToken);
+}

--- a/src/main/java/ru/dreadblade/czarbank/security/service/AuthenticationService.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/service/AuthenticationService.java
@@ -12,12 +12,10 @@ import ru.dreadblade.czarbank.exception.ExceptionMessage;
 
 @Service
 public class AuthenticationService {
-    private final AccessTokenService accessTokenService;
     private final AuthenticationManager authenticationManager;
 
     @Autowired
-    public AuthenticationService(AccessTokenService accessTokenService, AuthenticationManager authenticationManager) {
-        this.accessTokenService = accessTokenService;
+    public AuthenticationService(AuthenticationManager authenticationManager) {
         this.authenticationManager = authenticationManager;
     }
 
@@ -36,9 +34,5 @@ public class AuthenticationService {
         }
 
         throw new EntityNotFoundException(ExceptionMessage.USER_NOT_FOUND);
-    }
-
-    public String getAccessToken(User user) {
-        return accessTokenService.generateAccessToken(user);
     }
 }

--- a/src/main/java/ru/dreadblade/czarbank/security/service/RefreshTokenService.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/service/RefreshTokenService.java
@@ -17,6 +17,9 @@ public class RefreshTokenService {
     @Value("${czar-bank.security.json-web-token.refresh-token.expiration-seconds}")
     private Long expirationSeconds;
 
+    @Value("${czar-bank.security.json-web-token.refresh-token.limit-per-user}")
+    private Long refreshTokensPerUser;
+
     private final AccessTokenService accessTokenService;
     private final RefreshTokenSessionRepository refreshTokenSessionRepository;
 
@@ -26,6 +29,10 @@ public class RefreshTokenService {
     }
 
     public String generateRefreshToken(User user) {
+        if (refreshTokenSessionRepository.countByUser(user) >= refreshTokensPerUser) {
+            refreshTokenSessionRepository.markRevokedAllByUser(user);
+        }
+
         RefreshTokenSession session = RefreshTokenSession.builder()
                 .refreshToken(generateRefreshToken())
                 .user(user)

--- a/src/main/java/ru/dreadblade/czarbank/security/service/RefreshTokenService.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/service/RefreshTokenService.java
@@ -1,0 +1,76 @@
+package ru.dreadblade.czarbank.security.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import ru.dreadblade.czarbank.domain.security.RefreshTokenSession;
+import ru.dreadblade.czarbank.domain.security.User;
+import ru.dreadblade.czarbank.exception.ExceptionMessage;
+import ru.dreadblade.czarbank.exception.RefreshTokenException;
+import ru.dreadblade.czarbank.repository.security.RefreshTokenSessionRepository;
+
+import java.time.Instant;
+import java.util.UUID;
+import java.util.function.Predicate;
+
+@Service
+public class RefreshTokenService {
+    @Value("${czar-bank.security.json-web-token.refresh-token.expiration-seconds}")
+    private Long expirationSeconds;
+
+    private final AccessTokenService accessTokenService;
+    private final RefreshTokenSessionRepository refreshTokenSessionRepository;
+
+    public RefreshTokenService(AccessTokenService accessTokenService, RefreshTokenSessionRepository refreshTokenSessionRepository) {
+        this.accessTokenService = accessTokenService;
+        this.refreshTokenSessionRepository = refreshTokenSessionRepository;
+    }
+
+    public String generateRefreshToken(User user) {
+        RefreshTokenSession session = RefreshTokenSession.builder()
+                .refreshToken(generateRefreshToken())
+                .user(user)
+                .build();
+
+        refreshTokenSessionRepository.save(session);
+
+        return session.getRefreshToken();
+    }
+
+    public String updateAccessToken(String refreshToken) {
+        RefreshTokenSession session = refreshTokenSessionRepository.findByRefreshToken(refreshToken)
+                .filter(Predicate.not(RefreshTokenSession::getIsRevoked))
+                .orElseThrow(() -> new RefreshTokenException(ExceptionMessage.INVALID_REFRESH_TOKEN));
+
+        if (session.getCreatedAt().plusSeconds(expirationSeconds).isBefore(Instant.now())) {
+            throw new RefreshTokenException(ExceptionMessage.REFRESH_TOKEN_EXPIRED);
+        }
+
+        User user = session.getUser();
+
+        return accessTokenService.generateAccessToken(user);
+    }
+
+    public String updateRefreshToken(String refreshToken) {
+        RefreshTokenSession session = refreshTokenSessionRepository.findByRefreshToken(refreshToken)
+                .filter(Predicate.not(RefreshTokenSession::getIsRevoked))
+                .orElseThrow(() -> new RefreshTokenException(ExceptionMessage.INVALID_REFRESH_TOKEN));
+
+        if (session.getCreatedAt().plusSeconds(expirationSeconds).isBefore(Instant.now())) {
+            throw new RefreshTokenException(ExceptionMessage.REFRESH_TOKEN_EXPIRED);
+        }
+
+        session.setIsRevoked(true);
+
+        return generateRefreshToken(session.getUser());
+    }
+
+    private String generateRefreshToken() {
+        String refreshToken = UUID.randomUUID().toString();
+
+        while (refreshTokenSessionRepository.existsByRefreshToken(refreshToken)) {
+            refreshToken = UUID.randomUUID().toString();
+        }
+
+        return refreshToken;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,4 @@ czar-bank:
           prefix: 'Bearer '
       refresh-token:
         expiration-seconds: 604800
+        limit-per-user: 5

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,5 @@ czar-bank:
         secret-key: 'czar-bank-secret-key'
         header:
           prefix: 'Bearer '
+      refresh-token:
+        expiration-seconds: 604800

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/BaseIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/BaseIntegrationTest.java
@@ -37,9 +37,9 @@ public abstract class BaseIntegrationTest {
     protected final long BASE_PERMISSION_ID = 0L;
     protected final long BASE_ROLE_ID = 12L;
     protected final long BASE_USER_ID = 15L;
-    protected final long BASE_BANK_ACCOUNT_TYPE_ID = 21L;
-    protected final long BASE_BANK_ACCOUNT_ID = 26L;
-    protected final long BASE_TRANSACTION_ID = 31L;
+    protected final long BASE_BANK_ACCOUNT_TYPE_ID = 20L;
+    protected final long BASE_BANK_ACCOUNT_ID = 25L;
+    protected final long BASE_TRANSACTION_ID = 30L;
 
     @Autowired
     WebApplicationContext webApplicationContext;

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -17,3 +17,4 @@ czar-bank:
           prefix: 'Bearer '
       refresh-token:
         expiration-seconds: 604800
+        limit-per-user: 5

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -15,3 +15,5 @@ czar-bank:
         secret-key: 'czar-bank-secret-key'
         header:
           prefix: 'Bearer '
+      refresh-token:
+        expiration-seconds: 604800

--- a/src/test/resources/bank-account/bank-accounts-insertion.sql
+++ b/src/test/resources/bank-account/bank-accounts-insertion.sql
@@ -1,16 +1,16 @@
 delete from bank_account;
 delete from bank_account_type;
 
-insert into bank_account_type (id, name, transaction_commission) values (22, 'Czar', 0.01);
-insert into bank_account_type (id, name, transaction_commission) values (23, 'Nobleman', 0.02);
-insert into bank_account_type (id, name, transaction_commission) values (24, 'Junker', 0.03);
-insert into bank_account_type (id, name, transaction_commission) values (25, 'Standard', 0.04);
-insert into bank_account_type (id, name, transaction_commission) values (26, 'Unused account type', 0.10);
+insert into bank_account_type (id, name, transaction_commission) values (21, 'Czar', 0.01);
+insert into bank_account_type (id, name, transaction_commission) values (22, 'Nobleman', 0.02);
+insert into bank_account_type (id, name, transaction_commission) values (23, 'Junker', 0.03);
+insert into bank_account_type (id, name, transaction_commission) values (24, 'Standard', 0.04);
+insert into bank_account_type (id, name, transaction_commission) values (25, 'Unused account type', 0.10);
 
-insert into bank_account (id, balance, is_closed, number, owner_id, bank_account_type_id) values (27, 15000, false, '39903336089073190794', 19, 22);
-insert into bank_account (id, balance, is_closed, number, owner_id, bank_account_type_id) values (28, 5000, false, '33390474811219980161', 20, 23);
-insert into bank_account (id, balance, is_closed, number, owner_id, bank_account_type_id) values (29, 2000, false, '38040432731497506063', 18, 24);
-insert into bank_account (id, balance, is_closed, number, owner_id, bank_account_type_id) values (30, 500, false, '36264421013439107929', 20, 25);
-insert into bank_account (id, balance, is_closed, number, owner_id, bank_account_type_id) values (31, 1500, false, '32541935657215432384', 19, 25);
+insert into bank_account (id, balance, is_closed, number, owner_id, bank_account_type_id) values (26, 15000, false, '39903336089073190794', 19, 21);
+insert into bank_account (id, balance, is_closed, number, owner_id, bank_account_type_id) values (27, 5000, false, '33390474811219980161', 20, 22);
+insert into bank_account (id, balance, is_closed, number, owner_id, bank_account_type_id) values (28, 2000, false, '38040432731497506063', 18, 23);
+insert into bank_account (id, balance, is_closed, number, owner_id, bank_account_type_id) values (29, 500, false, '36264421013439107929', 20, 24);
+insert into bank_account (id, balance, is_closed, number, owner_id, bank_account_type_id) values (30, 1500, false, '32541935657215432384', 19, 24);
 
-alter sequence hibernate_sequence restart 32;
+alter sequence hibernate_sequence restart 31;

--- a/src/test/resources/transaction/transactions-insertion.sql
+++ b/src/test/resources/transaction/transactions-insertion.sql
@@ -1,8 +1,8 @@
 delete from transaction;
 
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (32, 1000, now(), 27, 28);
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (33, 2500, now(), 28, 29);
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (34, 1500, now(), 29, 30);
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (35, 250, now(), 30, 31);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (31, 1000, now(), 26, 27);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (32, 2500, now(), 27, 28);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (33, 1500, now(), 28, 29);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (34, 250, now(), 29, 30);
 
-alter sequence hibernate_sequence restart 36;
+alter sequence hibernate_sequence restart 35;

--- a/src/test/resources/user/users-deletion.sql
+++ b/src/test/resources/user/users-deletion.sql
@@ -1,4 +1,5 @@
 delete from user_role;
+delete from refresh_token_session;
 delete from users;
 delete from role_permission;
 delete from role;

--- a/src/test/resources/user/users-insertion.sql
+++ b/src/test/resources/user/users-insertion.sql
@@ -1,4 +1,5 @@
 delete from user_role;
+delete from refresh_token_session;
 delete from users;
 delete from role_permission;
 delete from role;
@@ -46,4 +47,4 @@ values (16, 13),
        (19, 15),
        (20, 15);
 
-alter sequence hibernate_sequence restart 22;
+alter sequence hibernate_sequence restart 21;


### PR DESCRIPTION
Added new API endpoint for refresh tokens: `/api/auth/refresh-tokens`
To refresh the tokens, you need to send the refresh token in the request body.
If the refresh token is not expired, it is marked as revoked and new access and refresh tokens are returned.
If the refresh token has expired or a modified exception is thrown and a Bad Request (400) is returned.