### PR TITLE
Added exchange rate functionality 

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,4 @@ coverage:
       default:
         target: 85%
         threshold: 1%
+    patch: off

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
 			<version>3.12.0</version>
 		</dependency>
 		<dependency>
+			<groupId>com.fasterxml.jackson.dataformat</groupId>
+			<artifactId>jackson-dataformat-xml</artifactId>
+			<version>${jackson-bom.version}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<version>${lombok.version}</version>
@@ -91,7 +96,12 @@
 			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
-
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<version>4.1.0</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -151,5 +161,4 @@
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -96,12 +96,6 @@
 			<version>${testcontainers.version}</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.awaitility</groupId>
-			<artifactId>awaitility</artifactId>
-			<version>4.1.0</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/ru/dreadblade/czarbank/api/controller/CurrencyController.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/controller/CurrencyController.java
@@ -2,13 +2,15 @@ package ru.dreadblade.czarbank.api.controller;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import ru.dreadblade.czarbank.api.mapper.CurrencyMapper;
+import ru.dreadblade.czarbank.api.model.request.CurrencyRequestDTO;
 import ru.dreadblade.czarbank.api.model.response.CurrencyResponseDTO;
+import ru.dreadblade.czarbank.domain.Currency;
 import ru.dreadblade.czarbank.service.CurrencyService;
 
+import javax.servlet.http.HttpServletRequest;
+import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,5 +31,16 @@ public class CurrencyController {
         return ResponseEntity.ok(currencyService.findAll().stream()
                 .map(currencyMapper::entityToResponseDTO)
                 .collect(Collectors.toList()));
+    }
+
+    @PostMapping
+    public ResponseEntity<CurrencyResponseDTO> createCurrency(@RequestBody CurrencyRequestDTO requestDTO, HttpServletRequest request) {
+        String currencyCode = requestDTO.getCode();
+        String currencySymbol = requestDTO.getSymbol();
+
+        Currency createdCurrency = currencyService.createCurrency(currencyCode, currencySymbol);
+
+        return ResponseEntity.created(URI.create(request.getRequestURI() + "/" + createdCurrency.getId()))
+                .body(currencyMapper.entityToResponseDTO(createdCurrency));
     }
 }

--- a/src/main/java/ru/dreadblade/czarbank/api/controller/ExchangeRateController.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/controller/ExchangeRateController.java
@@ -1,0 +1,49 @@
+package ru.dreadblade.czarbank.api.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+import ru.dreadblade.czarbank.api.mapper.ExchangeRateMapper;
+import ru.dreadblade.czarbank.api.model.response.ExchangeRateResponseDTO;
+import ru.dreadblade.czarbank.service.ExchangeRateService;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequestMapping("/api/currencies/exchange-rates")
+@RestController
+public class ExchangeRateController {
+    private final ExchangeRateService exchangeRateService;
+    private final ExchangeRateMapper exchangeRateMapper;
+
+    @Autowired
+    public ExchangeRateController(ExchangeRateService exchangeRateService, ExchangeRateMapper exchangeRateMapper) {
+        this.exchangeRateService = exchangeRateService;
+        this.exchangeRateMapper = exchangeRateMapper;
+    }
+
+    @GetMapping("/latest")
+    public List<ExchangeRateResponseDTO> findAllLatest() {
+        return exchangeRateService.findAllLatest().stream()
+                .map(exchangeRateMapper::entityToResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/historical/{date}")
+    public List<ExchangeRateResponseDTO> findAllByDate(@PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+        return exchangeRateService.findAllByDate(date).stream()
+                .map(exchangeRateMapper::entityToResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+    @GetMapping("/time-series")
+    public List<ExchangeRateResponseDTO> findAllInTimeSeries(
+            @RequestParam("start-date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate startDate,
+            @RequestParam("end-date") @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate endDate
+    ) {
+        return exchangeRateService.findAllInTimeSeries(startDate, endDate).stream()
+                .map(exchangeRateMapper::entityToResponseDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/api/mapper/ExchangeRateMapper.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/mapper/ExchangeRateMapper.java
@@ -1,0 +1,12 @@
+package ru.dreadblade.czarbank.api.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import ru.dreadblade.czarbank.api.model.response.ExchangeRateResponseDTO;
+import ru.dreadblade.czarbank.domain.ExchangeRate;
+
+@Mapper
+public interface ExchangeRateMapper {
+    @Mapping(target = "currencyId", source = "currency.id")
+    ExchangeRateResponseDTO entityToResponseDTO(ExchangeRate exchangeRate);
+}

--- a/src/main/java/ru/dreadblade/czarbank/api/model/request/CurrencyRequestDTO.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/model/request/CurrencyRequestDTO.java
@@ -1,4 +1,4 @@
-package ru.dreadblade.czarbank.api.model.response;
+package ru.dreadblade.czarbank.api.model.request;
 
 import lombok.*;
 
@@ -7,8 +7,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CurrencyResponseDTO {
-    private Long id;
+public class CurrencyRequestDTO {
     private String code;
     private String symbol;
 }

--- a/src/main/java/ru/dreadblade/czarbank/api/model/response/ExchangeRateResponseDTO.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/model/response/ExchangeRateResponseDTO.java
@@ -1,0 +1,18 @@
+package ru.dreadblade.czarbank.api.model.response;
+
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExchangeRateResponseDTO {
+    private Long id;
+    private Long currencyId;
+    private BigDecimal exchangeRate;
+    private LocalDate date;
+}

--- a/src/main/java/ru/dreadblade/czarbank/api/model/response/external/CbrExchangeRatesResponseDTO.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/model/response/external/CbrExchangeRatesResponseDTO.java
@@ -1,0 +1,47 @@
+package ru.dreadblade.czarbank.api.model.response.external;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import lombok.*;
+import ru.dreadblade.czarbank.util.BigDecimalDeserializer;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JacksonXmlRootElement(localName = "ValCurs")
+public class CbrExchangeRatesResponseDTO {
+
+    @JacksonXmlProperty(localName = "Date", isAttribute = true)
+    @JsonFormat(pattern = "dd.MM.yyyy")
+    private LocalDate date;
+
+    @JacksonXmlProperty(localName = "Valute")
+    @JacksonXmlElementWrapper(useWrapping = false)
+    private List<CbrExchangeRateResponseDTO> rates;
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CbrExchangeRateResponseDTO {
+        @JacksonXmlProperty(localName = "CharCode")
+        private String currencyCode;
+
+        @JacksonXmlProperty(localName = "Nominal")
+        private Long nominal;
+
+        @JacksonXmlProperty(localName = "Value")
+        @JsonDeserialize(using = BigDecimalDeserializer.class)
+        private BigDecimal rate;
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/config/CzarBankConfiguration.java
+++ b/src/main/java/ru/dreadblade/czarbank/config/CzarBankConfiguration.java
@@ -1,10 +1,15 @@
 package ru.dreadblade.czarbank.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.web.client.RestTemplate;
 
 @Configuration
 @EnableScheduling
 public class CzarBankConfiguration {
-
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
 }

--- a/src/main/java/ru/dreadblade/czarbank/config/CzarBankConfiguration.java
+++ b/src/main/java/ru/dreadblade/czarbank/config/CzarBankConfiguration.java
@@ -1,0 +1,10 @@
+package ru.dreadblade.czarbank.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class CzarBankConfiguration {
+
+}

--- a/src/main/java/ru/dreadblade/czarbank/domain/Currency.java
+++ b/src/main/java/ru/dreadblade/czarbank/domain/Currency.java
@@ -20,5 +20,5 @@ public class Currency {
 
     private String code;
 
-    private Character symbol;
+    private String symbol;
 }

--- a/src/main/java/ru/dreadblade/czarbank/domain/ExchangeRate.java
+++ b/src/main/java/ru/dreadblade/czarbank/domain/ExchangeRate.java
@@ -1,0 +1,29 @@
+package ru.dreadblade.czarbank.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class ExchangeRate {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    private Currency currency;
+
+    /**
+     * Exchange rate against the Russian Ruble
+     */
+    private BigDecimal exchangeRate;
+
+    private LocalDate date;
+}

--- a/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 public enum ExceptionMessage {
     BANK_ACCOUNT_TYPE_NOT_FOUND("Bank account type doesn't exist", HttpStatus.NOT_FOUND),
     CURRENCY_NOT_FOUND("Currency doesn't exist", HttpStatus.NOT_FOUND),
+    LATEST_EXCHANGE_RATES_NOT_FOUND("Error while loading the latest currency rates", HttpStatus.INTERNAL_SERVER_ERROR),
+    EXCHANGE_RATES_AT_DATE_NOT_FOUND("No exchange rates found for the date ", HttpStatus.NOT_FOUND),
     BANK_ACCOUNT_NOT_FOUND("Bank account doesn't exist", HttpStatus.NOT_FOUND),
     PERMISSION_NOT_FOUND("Permission doesn't exist", HttpStatus.NOT_FOUND),
     ROLE_NOT_FOUND("Role doesn't exist", HttpStatus.NOT_FOUND),

--- a/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
@@ -15,6 +15,8 @@ public enum ExceptionMessage {
     USER_NOT_FOUND("User doesn't exist", HttpStatus.NOT_FOUND),
 
     BANK_ACCOUNT_TYPE_NAME_ALREADY_EXISTS("Bank account type with same name already exists", HttpStatus.BAD_REQUEST),
+    CURRENCY_CODE_ALREADY_EXISTS("Currency with same code already exists", HttpStatus.BAD_REQUEST),
+    CURRENCY_SYMBOL_ALREADY_EXISTS("Currency with same symbol already exists", HttpStatus.BAD_REQUEST),
     ROLE_NAME_ALREADY_EXISTS("Role with same name already exists", HttpStatus.BAD_REQUEST),
     USERNAME_ALREADY_EXISTS("User with same username already exists", HttpStatus.BAD_REQUEST),
     USER_EMAIL_ALREADY_EXISTS("Role with same email already exists", HttpStatus.BAD_REQUEST),
@@ -22,6 +24,8 @@ public enum ExceptionMessage {
     BANK_ACCOUNT_TYPE_IN_USE("Bank account type in use", HttpStatus.BAD_REQUEST),
 
     NOT_ENOUGH_BALANCE("Not enough balance", HttpStatus.BAD_REQUEST),
+
+    UNSUPPORTED_CURRENCY("Currency is not supported", HttpStatus.BAD_REQUEST),
 
     REFRESH_TOKEN_EXPIRED("Refresh token expired", HttpStatus.BAD_REQUEST),
     INVALID_REFRESH_TOKEN("Invalid refresh token", HttpStatus.BAD_REQUEST);

--- a/src/main/java/ru/dreadblade/czarbank/exception/UnsupportedCurrencyException.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/UnsupportedCurrencyException.java
@@ -1,0 +1,7 @@
+package ru.dreadblade.czarbank.exception;
+
+public class UnsupportedCurrencyException extends BaseException {
+    public UnsupportedCurrencyException(ExceptionMessage exceptionMessage) {
+        super(exceptionMessage.getMessage(), exceptionMessage.getStatus());
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/repository/CurrencyRepository.java
+++ b/src/main/java/ru/dreadblade/czarbank/repository/CurrencyRepository.java
@@ -3,5 +3,8 @@ package ru.dreadblade.czarbank.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import ru.dreadblade.czarbank.domain.Currency;
 
+import java.util.Optional;
+
 public interface CurrencyRepository extends JpaRepository<Currency, Long> {
+    Optional<Currency> findByCode(String code);
 }

--- a/src/main/java/ru/dreadblade/czarbank/repository/CurrencyRepository.java
+++ b/src/main/java/ru/dreadblade/czarbank/repository/CurrencyRepository.java
@@ -7,4 +7,8 @@ import java.util.Optional;
 
 public interface CurrencyRepository extends JpaRepository<Currency, Long> {
     Optional<Currency> findByCode(String code);
+
+    boolean existsByCode(String code);
+
+    boolean existsBySymbol(String symbol);
 }

--- a/src/main/java/ru/dreadblade/czarbank/repository/ExchangeRateRepository.java
+++ b/src/main/java/ru/dreadblade/czarbank/repository/ExchangeRateRepository.java
@@ -1,0 +1,12 @@
+package ru.dreadblade.czarbank.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ru.dreadblade.czarbank.domain.Currency;
+import ru.dreadblade.czarbank.domain.ExchangeRate;
+
+import java.time.LocalDate;
+
+public interface ExchangeRateRepository extends JpaRepository<ExchangeRate, Long> {
+    boolean existsByCurrencyAndDate(Currency currency, LocalDate date);
+    void deleteByCurrencyAndDate(Currency currency, LocalDate date);
+}

--- a/src/main/java/ru/dreadblade/czarbank/repository/ExchangeRateRepository.java
+++ b/src/main/java/ru/dreadblade/czarbank/repository/ExchangeRateRepository.java
@@ -1,12 +1,24 @@
 package ru.dreadblade.czarbank.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import ru.dreadblade.czarbank.domain.Currency;
 import ru.dreadblade.czarbank.domain.ExchangeRate;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public interface ExchangeRateRepository extends JpaRepository<ExchangeRate, Long> {
+    @Query("select e from ExchangeRate as e where e.date in (select max(date) from ExchangeRate)")
+    List<ExchangeRate> findAllLatest();
+
+    List<ExchangeRate> findAllByDate(LocalDate date);
+
+    @Query("select e from ExchangeRate as e where e.date between :start_date and :end_date order by e.date asc")
+    List<ExchangeRate> findAllInTimeSeries(@Param("start_date") LocalDate startDate, @Param("end_date") LocalDate endDate);
+
     boolean existsByCurrencyAndDate(Currency currency, LocalDate date);
+
     void deleteByCurrencyAndDate(Currency currency, LocalDate date);
 }

--- a/src/main/java/ru/dreadblade/czarbank/service/CurrencyService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/CurrencyService.java
@@ -3,20 +3,58 @@ package ru.dreadblade.czarbank.service;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import ru.dreadblade.czarbank.domain.Currency;
+import ru.dreadblade.czarbank.exception.ExceptionMessage;
+import ru.dreadblade.czarbank.exception.UnsupportedCurrencyException;
+import ru.dreadblade.czarbank.exception.UniqueFieldAlreadyExistsException;
 import ru.dreadblade.czarbank.repository.CurrencyRepository;
+import ru.dreadblade.czarbank.repository.ExchangeRateRepository;
+import ru.dreadblade.czarbank.service.task.Task;
 
 import java.util.List;
 
 @Service
 public class CurrencyService {
     private final CurrencyRepository currencyRepository;
+    private final ExchangeRateRepository exchangeRateRepository;
+    private final Task fetchExchangeRatesFromCbrTask;
 
     @Autowired
-    public CurrencyService(CurrencyRepository currencyRepository) {
+    public CurrencyService(CurrencyRepository currencyRepository, ExchangeRateRepository exchangeRateRepository, Task fetchExchangeRatesFromCbrTask) {
         this.currencyRepository = currencyRepository;
+        this.exchangeRateRepository = exchangeRateRepository;
+        this.fetchExchangeRatesFromCbrTask = fetchExchangeRatesFromCbrTask;
     }
 
     public List<Currency> findAll() {
         return currencyRepository.findAll();
+    }
+
+    public Currency createCurrency(String currencyCode, String currencySymbol) {
+        if (currencyRepository.existsByCode(currencyCode)) {
+            throw new UniqueFieldAlreadyExistsException(ExceptionMessage.CURRENCY_CODE_ALREADY_EXISTS);
+        }
+
+        if (currencyRepository.existsBySymbol(currencySymbol)) {
+            throw new UniqueFieldAlreadyExistsException(ExceptionMessage.CURRENCY_SYMBOL_ALREADY_EXISTS);
+        }
+
+        Currency createdCurrency = currencyRepository.save(Currency.builder()
+                .code(currencyCode)
+                .symbol(currencySymbol)
+                .build());
+
+        fetchExchangeRatesFromCbrTask.execute();
+
+        boolean exchangeRateForCurrencyExists = exchangeRateRepository.findAllLatest()
+                .stream()
+                .filter(exchangeRate -> exchangeRate.getCurrency().getCode().equals(createdCurrency.getCode()))
+                .count() == 1;
+
+        if (!exchangeRateForCurrencyExists) {
+            currencyRepository.deleteById(createdCurrency.getId());
+            throw new UnsupportedCurrencyException(ExceptionMessage.UNSUPPORTED_CURRENCY);
+        }
+
+        return createdCurrency;
     }
 }

--- a/src/main/java/ru/dreadblade/czarbank/service/ExchangeRateService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/ExchangeRateService.java
@@ -1,0 +1,84 @@
+package ru.dreadblade.czarbank.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import ru.dreadblade.czarbank.api.model.response.external.CbrExchangeRatesResponseDTO;
+import ru.dreadblade.czarbank.domain.Currency;
+import ru.dreadblade.czarbank.domain.ExchangeRate;
+import ru.dreadblade.czarbank.exception.EntityNotFoundException;
+import ru.dreadblade.czarbank.exception.ExceptionMessage;
+import ru.dreadblade.czarbank.repository.CurrencyRepository;
+import ru.dreadblade.czarbank.repository.ExchangeRateRepository;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class ExchangeRateService {
+
+    private static final String EXCHANGE_RATE_API_URL = "https://www.cbr.ru/scripts/XML_daily.asp";
+
+    private final ExchangeRateRepository exchangeRateRepository;
+    private final CurrencyRepository currencyRepository;
+    private final RestTemplate restTemplate;
+
+    public ExchangeRateService(ExchangeRateRepository exchangeRateRepository, CurrencyRepository currencyRepository) {
+        this.exchangeRateRepository = exchangeRateRepository;
+        this.currencyRepository = currencyRepository;
+        this.restTemplate = new RestTemplate();
+    }
+
+    @Transactional
+    @Scheduled(fixedRateString = "${czar-bank.currency.exchange-rate.update-rate-in-millis:3600000}")
+    public void fetchExchangeRatesFromCentralBankOfRussia() {
+        ResponseEntity<CbrExchangeRatesResponseDTO> response = restTemplate
+                .getForEntity(EXCHANGE_RATE_API_URL, CbrExchangeRatesResponseDTO.class);
+
+        CbrExchangeRatesResponseDTO responseDTO = response.getBody();
+
+        if (!response.getStatusCode().is2xxSuccessful() || responseDTO == null || responseDTO.getRates() == null ||
+                responseDTO.getRates().isEmpty()) {
+            log.error("Error when fetching currency exchange rates from the API of the Central Bank of Russia");
+            return;
+        }
+
+        List<String> usedCurrencies = currencyRepository.findAll().stream()
+                .map(Currency::getCode)
+                .collect(Collectors.toList());
+
+        List<ExchangeRate> exchangeRates = responseDTO.getRates().stream()
+                .filter(dto -> usedCurrencies.contains(dto.getCurrencyCode()))
+                .map(dto -> {
+                    if (dto.getNominal() > 1) {
+                        dto.setRate(dto.getRate().divide(BigDecimal.valueOf(dto.getNominal()), RoundingMode.HALF_UP));
+                    }
+
+                    Currency currency = currencyRepository.findByCode(dto.getCurrencyCode())
+                            .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.CURRENCY_NOT_FOUND));
+
+                    return ExchangeRate.builder()
+                            .currency(currency)
+                            .exchangeRate(dto.getRate())
+                            .date(responseDTO.getDate())
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        for (ExchangeRate exchangeRate : exchangeRates) {
+            if (exchangeRateRepository.existsByCurrencyAndDate(exchangeRate.getCurrency(), exchangeRate.getDate())) {
+                exchangeRateRepository.deleteByCurrencyAndDate(exchangeRate.getCurrency(), exchangeRate.getDate());
+            }
+        }
+
+        exchangeRateRepository.saveAll(exchangeRates);
+
+        log.info("Fetching currency exchange rates from the API of the Central Bank of Russia completed successfully");
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/service/ExchangeRateService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/ExchangeRateService.java
@@ -46,7 +46,9 @@ public class ExchangeRateService {
     public List<ExchangeRate> findAllInTimeSeries(LocalDate startDate, LocalDate endDate) {
         List<ExchangeRate> exchangeRates = exchangeRateRepository.findAllInTimeSeries(startDate, endDate);
 
-        if (exchangeRates.isEmpty() || ChronoUnit.DAYS.between(startDate, endDate) + 1L > exchangeRates.size()) {
+        long exchangeRatesPerCurrency = exchangeRates.size() / (currencyRepository.count() - 1L);
+
+        if (exchangeRates.isEmpty() || ChronoUnit.DAYS.between(startDate, endDate) + 1L > exchangeRatesPerCurrency) {
             throw new EntityNotFoundException(ExceptionMessage.EXCHANGE_RATES_AT_DATE_NOT_FOUND);
         }
 

--- a/src/main/java/ru/dreadblade/czarbank/service/FetchExchangeRateService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/FetchExchangeRateService.java
@@ -1,0 +1,89 @@
+package ru.dreadblade.czarbank.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import ru.dreadblade.czarbank.api.model.response.external.CbrExchangeRatesResponseDTO;
+import ru.dreadblade.czarbank.domain.Currency;
+import ru.dreadblade.czarbank.domain.ExchangeRate;
+import ru.dreadblade.czarbank.exception.EntityNotFoundException;
+import ru.dreadblade.czarbank.exception.ExceptionMessage;
+import ru.dreadblade.czarbank.repository.CurrencyRepository;
+import ru.dreadblade.czarbank.repository.ExchangeRateRepository;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+public class FetchExchangeRateService {
+
+    private static final String EXCHANGE_RATE_API_URL = "https://www.cbr.ru/scripts/XML_daily.asp";
+
+    private final ExchangeRateRepository exchangeRateRepository;
+    private final CurrencyRepository currencyRepository;
+    private final RestTemplate restTemplate;
+
+    public FetchExchangeRateService(ExchangeRateRepository exchangeRateRepository, CurrencyRepository currencyRepository) {
+        this.exchangeRateRepository = exchangeRateRepository;
+        this.currencyRepository = currencyRepository;
+        this.restTemplate = new RestTemplate();
+    }
+
+    @Transactional
+    @Scheduled(fixedRateString = "${czar-bank.currency.exchange-rate.update-rate-in-millis:3600000}")
+    public void fetchExchangeRatesFromCentralBankOfRussia() {
+        ResponseEntity<CbrExchangeRatesResponseDTO> response = restTemplate
+                .getForEntity(EXCHANGE_RATE_API_URL, CbrExchangeRatesResponseDTO.class);
+
+        CbrExchangeRatesResponseDTO responseDTO = response.getBody();
+
+        if (!response.getStatusCode().is2xxSuccessful() || responseDTO == null || responseDTO.getRates() == null ||
+                responseDTO.getRates().isEmpty()) {
+            log.error("Error when fetching currency exchange rates from the API of the Central Bank of Russia");
+            return;
+        }
+
+        if (responseDTO.getDate().isBefore(LocalDate.now())) {
+            responseDTO.setDate(LocalDate.now());
+        }
+
+        List<String> usedCurrencies = currencyRepository.findAll().stream()
+                .map(Currency::getCode)
+                .collect(Collectors.toList());
+
+        List<ExchangeRate> exchangeRates = responseDTO.getRates().stream()
+                .filter(dto -> usedCurrencies.contains(dto.getCurrencyCode()))
+                .map(dto -> {
+                    if (dto.getNominal() > 1) {
+                        dto.setRate(dto.getRate().divide(BigDecimal.valueOf(dto.getNominal()), RoundingMode.HALF_UP));
+                    }
+
+                    Currency currency = currencyRepository.findByCode(dto.getCurrencyCode())
+                            .orElseThrow(() -> new EntityNotFoundException(ExceptionMessage.CURRENCY_NOT_FOUND));
+
+                    return ExchangeRate.builder()
+                            .currency(currency)
+                            .exchangeRate(dto.getRate())
+                            .date(responseDTO.getDate())
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        for (ExchangeRate exchangeRate : exchangeRates) {
+            if (exchangeRateRepository.existsByCurrencyAndDate(exchangeRate.getCurrency(), exchangeRate.getDate())) {
+                exchangeRateRepository.deleteByCurrencyAndDate(exchangeRate.getCurrency(), exchangeRate.getDate());
+            }
+        }
+
+        exchangeRateRepository.saveAll(exchangeRates);
+
+        log.info("Fetching currency exchange rates from the API of the Central Bank of Russia completed successfully");
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/service/task/ScheduledTasks.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/task/ScheduledTasks.java
@@ -1,0 +1,22 @@
+package ru.dreadblade.czarbank.service.task;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ScheduledTasks {
+    private final FetchExchangeRatesFromCbrTask fetchExchangeRatesFromCbrTask;
+
+    @Scheduled(fixedRateString = "${czar-bank.currency.exchange-rate.update-rate-in-millis:3600000}")
+    public void fetchExchangeRatesFromCbr() {
+        if (fetchExchangeRatesFromCbrTask.execute()) {
+            log.info("Fetching currency exchange rates from the API of the Central Bank of Russia completed successfully");
+        } else {
+            log.error("Error when fetching currency exchange rates from the API of the Central Bank of Russia");
+        }
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/service/task/Task.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/task/Task.java
@@ -1,0 +1,8 @@
+package ru.dreadblade.czarbank.service.task;
+
+public interface Task {
+    /**
+     * @return {@code true} if task is completed successfully, otherwise - {@code false}
+     */
+    boolean execute();
+}

--- a/src/main/java/ru/dreadblade/czarbank/util/BigDecimalDeserializer.java
+++ b/src/main/java/ru/dreadblade/czarbank/util/BigDecimalDeserializer.java
@@ -1,0 +1,18 @@
+package ru.dreadblade.czarbank.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+
+public class BigDecimalDeserializer extends JsonDeserializer<BigDecimal> {
+    @Override
+    public BigDecimal deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        String rawValue = p.getValueAsString().replace(",", ".");
+
+        return new BigDecimal(rawValue);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,9 @@ spring:
       ddl-auto: update
 
 czar-bank:
+  currency:
+    exchange-rate:
+      update-rate-in-millis: 3600000
   security:
     json-web-token:
       access-token:

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/BaseIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/BaseIntegrationTest.java
@@ -39,8 +39,9 @@ public abstract class BaseIntegrationTest {
     protected final long BASE_USER_ID = 15L;
     protected final long BASE_BANK_ACCOUNT_TYPE_ID = 20L;
     protected final long BASE_CURRENCY_ID = 25L;
-    protected final long BASE_BANK_ACCOUNT_ID = 28L;
-    protected final long BASE_TRANSACTION_ID = 33L;
+    protected final long BASE_EXCHANGE_RATE_ID = 28L;
+    protected final long BASE_BANK_ACCOUNT_ID = 38L;
+    protected final long BASE_TRANSACTION_ID = 43L;
 
     @Autowired
     WebApplicationContext webApplicationContext;

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/CurrencyIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/CurrencyIntegrationTest.java
@@ -12,6 +12,7 @@ import ru.dreadblade.czarbank.api.mapper.CurrencyMapper;
 import ru.dreadblade.czarbank.api.model.response.CurrencyResponseDTO;
 import ru.dreadblade.czarbank.repository.BankAccountRepository;
 import ru.dreadblade.czarbank.repository.CurrencyRepository;
+import ru.dreadblade.czarbank.repository.ExchangeRateRepository;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,6 +30,9 @@ public class CurrencyIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     BankAccountRepository bankAccountRepository;
+
+    @Autowired
+    ExchangeRateRepository exchangeRateRepository;
 
     @Autowired
     CurrencyRepository currencyRepository;
@@ -59,6 +63,7 @@ public class CurrencyIntegrationTest extends BaseIntegrationTest {
         @Rollback
         void findAll_isEmpty() throws Exception {
             bankAccountRepository.deleteAll();
+            exchangeRateRepository.deleteAll();
             currencyRepository.deleteAll();
 
             long expectedSize = 0L;

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/CurrencyIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/CurrencyIntegrationTest.java
@@ -6,10 +6,14 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.jdbc.Sql;
 import ru.dreadblade.czarbank.api.mapper.CurrencyMapper;
+import ru.dreadblade.czarbank.api.model.request.CurrencyRequestDTO;
 import ru.dreadblade.czarbank.api.model.response.CurrencyResponseDTO;
+import ru.dreadblade.czarbank.exception.ExceptionMessage;
 import ru.dreadblade.czarbank.repository.BankAccountRepository;
 import ru.dreadblade.czarbank.repository.CurrencyRepository;
 import ru.dreadblade.czarbank.repository.ExchangeRateRepository;
@@ -17,8 +21,10 @@ import ru.dreadblade.czarbank.repository.ExchangeRateRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
@@ -73,6 +79,93 @@ public class CurrencyIntegrationTest extends BaseIntegrationTest {
             mockMvc.perform(get(CURRENCIES_API_URL))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$", hasSize(Math.toIntExact(expectedSize))));
+        }
+    }
+
+    @Nested
+    @DisplayName("createCurrency() Tests")
+    class createCurrencyTests {
+        @Test
+        @Rollback
+        void createCurrency_isSuccessful() throws Exception {
+            CurrencyRequestDTO requestDTO = CurrencyRequestDTO.builder()
+                    .code("SEK")
+                    .symbol("kr")
+                    .build();
+
+            Assertions.assertThat(currencyRepository.existsByCode(requestDTO.getCode())).isFalse();
+            Assertions.assertThat(currencyRepository.existsBySymbol(requestDTO.getSymbol())).isFalse();
+
+            String requestContent = objectMapper.writeValueAsString(requestDTO);
+
+            mockMvc.perform(post(CURRENCIES_API_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestContent))
+                    .andExpect(status().isCreated())
+                    .andExpect(header().string(HttpHeaders.LOCATION, containsString(CURRENCIES_API_URL)))
+                    .andExpect(jsonPath("$.id").isNumber())
+                    .andExpect(jsonPath("$.code").value(requestDTO.getCode()))
+                    .andExpect(jsonPath("$.symbol").value(requestDTO.getSymbol()));
+        }
+
+        @Test
+        void createCurrency_currencyCodeAlreadyExists_isFailed() throws Exception {
+            CurrencyRequestDTO requestDTO = CurrencyRequestDTO.builder()
+                    .code("RUB")
+                    .symbol("₽")
+                    .build();
+
+            Assertions.assertThat(currencyRepository.existsByCode(requestDTO.getCode())).isTrue();
+            Assertions.assertThat(currencyRepository.existsBySymbol(requestDTO.getSymbol())).isTrue();
+
+            String requestContent = objectMapper.writeValueAsString(requestDTO);
+
+            mockMvc.perform(post(CURRENCIES_API_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestContent))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message")
+                            .value(ExceptionMessage.CURRENCY_CODE_ALREADY_EXISTS.getMessage()));
+        }
+
+        @Test
+        void createCurrency_currencySymbolAlreadyExists_isFailed() throws Exception {
+            CurrencyRequestDTO requestDTO = CurrencyRequestDTO.builder()
+                    .code("newUSD")
+                    .symbol("$")
+                    .build();
+
+            Assertions.assertThat(currencyRepository.existsByCode(requestDTO.getCode())).isFalse();
+            Assertions.assertThat(currencyRepository.existsBySymbol(requestDTO.getSymbol())).isTrue();
+
+            String requestContent = objectMapper.writeValueAsString(requestDTO);
+
+            mockMvc.perform(post(CURRENCIES_API_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestContent))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message")
+                            .value(ExceptionMessage.CURRENCY_SYMBOL_ALREADY_EXISTS.getMessage()));
+        }
+
+        @Test
+        void createCurrency_currencyDoesNotExistOnCbr_isFailed() throws Exception {
+            CurrencyRequestDTO requestDTO = CurrencyRequestDTO.builder()
+                    .code("MNT")
+                    .symbol("₮")
+                    .build();
+
+            Assertions.assertThat(currencyRepository.existsByCode(requestDTO.getCode())).isFalse();
+            Assertions.assertThat(currencyRepository.existsBySymbol(requestDTO.getSymbol())).isFalse();
+
+            String requestContent = objectMapper.writeValueAsString(requestDTO);
+
+            mockMvc.perform(post(CURRENCIES_API_URL)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(requestContent))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message")
+                            .value(ExceptionMessage.UNSUPPORTED_CURRENCY.getMessage()));
         }
     }
 }

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/ExchangeRateIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/ExchangeRateIntegrationTest.java
@@ -3,25 +3,46 @@ package ru.dreadblade.czarbank.api.controller;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.jdbc.Sql;
+import org.springframework.web.util.UriComponentsBuilder;
+import ru.dreadblade.czarbank.api.mapper.ExchangeRateMapper;
+import ru.dreadblade.czarbank.api.model.response.ExchangeRateResponseDTO;
+import ru.dreadblade.czarbank.exception.ExceptionMessage;
 import ru.dreadblade.czarbank.repository.CurrencyRepository;
 import ru.dreadblade.czarbank.repository.ExchangeRateRepository;
-import ru.dreadblade.czarbank.service.ExchangeRateService;
+import ru.dreadblade.czarbank.service.FetchExchangeRateService;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
-@SpringBootTest(properties = {
-        "czar-bank.currency.exchange-rate.update-rate-in-millis=5000"
-})
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(properties = { "czar-bank.currency.exchange-rate.update-rate-in-millis=5000" })
 @DisplayName("ExchangeRate Integration Tests")
 @Sql(value = { "/user/users-insertion.sql", "/bank-account/bank-accounts-insertion.sql" }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(value = { "/bank-account/bank-accounts-deletion.sql", "/user/users-deletion.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 public class ExchangeRateIntegrationTest extends BaseIntegrationTest {
+
+    private static final String EXCHANGE_RATES_API_URL = "/api/currencies/exchange-rates";
+    private static final String LATEST = "/latest";
+    private static final String HISTORICAL = "/historical/";
+    private static final String TIME_SERIES = "/time-series/";
+    private static final String START_DATE_PARAM = "start-date";
+    private static final String END_DATE_PARAM = "end-date";
 
     @Autowired
     CurrencyRepository currencyRepository;
@@ -29,14 +50,146 @@ public class ExchangeRateIntegrationTest extends BaseIntegrationTest {
     @Autowired
     ExchangeRateRepository exchangeRateRepository;
 
+    @Autowired
+    ExchangeRateMapper exchangeRateMapper;
+
     @SpyBean
-    ExchangeRateService exchangeRateService;
+    FetchExchangeRateService fetchExchangeRateService;
 
     @Test
     void fetchExchangeRatesFromCentralBankOfRussia_runsAndIsSuccessful() {
         Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() ->
-                Mockito.verify(exchangeRateService, Mockito.atLeastOnce()).fetchExchangeRatesFromCentralBankOfRussia());
+                Mockito.verify(fetchExchangeRateService, Mockito.atLeastOnce()).fetchExchangeRatesFromCentralBankOfRussia());
 
         Assertions.assertThat(exchangeRateRepository.count()).isGreaterThanOrEqualTo(currencyRepository.count() - 1L);
+    }
+
+    @Nested
+    @DisplayName("findAllLatest() Tests")
+    class findAllLatestTests {
+        @Test
+        void findAllLatest_isSuccessful() throws Exception {
+            List<ExchangeRateResponseDTO> expectedResponseDTOs = exchangeRateRepository.findAllLatest().stream()
+                    .map(exchangeRateMapper::entityToResponseDTO)
+                    .collect(Collectors.toList());
+
+            long expectedSize = currencyRepository.count() - 1L;
+
+            String expectedResponse = objectMapper.writeValueAsString(expectedResponseDTOs);
+
+            mockMvc.perform(get(EXCHANGE_RATES_API_URL + LATEST)
+                    .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(Math.toIntExact(expectedSize))))
+                    .andExpect(content().json(expectedResponse));
+        }
+
+        @Test
+        @Rollback
+        void findAllLatest_isEmpty() throws Exception {
+            exchangeRateRepository.deleteAll();
+
+            final long expectedSize = 0L;
+
+            Assertions.assertThat(exchangeRateRepository.count()).isEqualTo(expectedSize);
+
+            mockMvc.perform(get(EXCHANGE_RATES_API_URL + LATEST)
+                    .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isInternalServerError())
+                    .andExpect(jsonPath("$.message")
+                            .value(ExceptionMessage.LATEST_EXCHANGE_RATES_NOT_FOUND.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllByDate() Tests")
+    class findAllByDateTests {
+        @Test
+        void findAllByDate_isSuccessful() throws Exception {
+            LocalDate expectedDate = exchangeRateRepository.findById(BASE_EXCHANGE_RATE_ID + 5L).orElseThrow().getDate();
+
+            String dateStr = expectedDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+            List<ExchangeRateResponseDTO> expectedResponseDTOs = exchangeRateRepository.findAllByDate(expectedDate).stream()
+                    .map(exchangeRateMapper::entityToResponseDTO)
+                    .collect(Collectors.toList());
+
+            long expectedSize = currencyRepository.count() - 1L;
+
+            String expectedResponse = objectMapper.writeValueAsString(expectedResponseDTOs);
+
+            mockMvc.perform(get(EXCHANGE_RATES_API_URL + HISTORICAL + dateStr))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(Math.toIntExact(expectedSize))))
+                    .andExpect(content().json(expectedResponse));
+        }
+
+        @Test
+        void findAllByDate_dataDoesNotExistOnTheGivenDate() throws Exception {
+            LocalDate expectedDate = LocalDate.of(2010, 6, 10);
+
+            String dateStr = expectedDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+            mockMvc.perform(get(EXCHANGE_RATES_API_URL + HISTORICAL + dateStr))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message")
+                            .value(ExceptionMessage.EXCHANGE_RATES_AT_DATE_NOT_FOUND.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("findAllInTimeSeries() Tests")
+    class findAllInTimeSeriesTests {
+        @Test
+        void findAllInTimeSeries_isSuccessful() throws Exception {
+            LocalDate startDate = exchangeRateRepository.findById(BASE_EXCHANGE_RATE_ID + 1L).orElseThrow().getDate();
+            LocalDate endDate = exchangeRateRepository.findById(BASE_EXCHANGE_RATE_ID + 10L).orElseThrow().getDate();
+
+            String startDateStr = startDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+            String endDateStr = endDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+            String URL = UriComponentsBuilder.fromUriString(EXCHANGE_RATES_API_URL + TIME_SERIES)
+                    .queryParam(START_DATE_PARAM, startDateStr)
+                    .queryParam(END_DATE_PARAM, endDateStr)
+                    .encode()
+                    .build()
+                    .toUriString();
+
+            List<ExchangeRateResponseDTO> expectedResponseDTOs = exchangeRateRepository.findAllInTimeSeries(startDate, endDate).stream()
+                    .map(exchangeRateMapper::entityToResponseDTO)
+                    .collect(Collectors.toList());
+
+            long expectedSize = (currencyRepository.count() - 1L) * (ChronoUnit.DAYS.between(startDate, endDate) + 1L);
+
+            String expectedResponse = objectMapper.writeValueAsString(expectedResponseDTOs);
+
+            mockMvc.perform(get(URL)
+                    .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$", hasSize(Math.toIntExact(expectedSize))))
+                    .andExpect(content().json(expectedResponse));
+        }
+
+        @Test
+        void findAllInTimeSeries_dataDoesNotExistOnTheGivenDate() throws Exception {
+            LocalDate startDate = LocalDate.of(2009, 6, 10);
+            LocalDate endDate = LocalDate.of(2010, 6, 10);
+
+            String startDateStr = startDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+            String endDateStr = endDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+
+            String URL = UriComponentsBuilder.fromUriString(EXCHANGE_RATES_API_URL + TIME_SERIES)
+                    .queryParam(START_DATE_PARAM, startDateStr)
+                    .queryParam(END_DATE_PARAM, endDateStr)
+                    .encode()
+                    .build()
+                    .toUriString();
+
+            mockMvc.perform(get(URL)
+                    .accept(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.message")
+                            .value(ExceptionMessage.EXCHANGE_RATES_AT_DATE_NOT_FOUND.getMessage()));
+        }
     }
 }

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/ExchangeRateIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/ExchangeRateIntegrationTest.java
@@ -1,0 +1,42 @@
+package ru.dreadblade.czarbank.api.controller;
+
+import org.assertj.core.api.Assertions;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.jdbc.Sql;
+import ru.dreadblade.czarbank.repository.CurrencyRepository;
+import ru.dreadblade.czarbank.repository.ExchangeRateRepository;
+import ru.dreadblade.czarbank.service.ExchangeRateService;
+
+import java.util.concurrent.TimeUnit;
+
+@SpringBootTest(properties = {
+        "czar-bank.currency.exchange-rate.update-rate-in-millis=5000"
+})
+@DisplayName("ExchangeRate Integration Tests")
+@Sql(value = { "/user/users-insertion.sql", "/bank-account/bank-accounts-insertion.sql" }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(value = { "/bank-account/bank-accounts-deletion.sql", "/user/users-deletion.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+public class ExchangeRateIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    CurrencyRepository currencyRepository;
+
+    @Autowired
+    ExchangeRateRepository exchangeRateRepository;
+
+    @SpyBean
+    ExchangeRateService exchangeRateService;
+
+    @Test
+    void fetchExchangeRatesFromCentralBankOfRussia_runsAndIsSuccessful() {
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Mockito.verify(exchangeRateService, Mockito.atLeastOnce()).fetchExchangeRatesFromCentralBankOfRussia());
+
+        Assertions.assertThat(exchangeRateRepository.count()).isGreaterThanOrEqualTo(currencyRepository.count() - 1L);
+    }
+}

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/ScheduledTasksIntegrationTests.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/ScheduledTasksIntegrationTests.java
@@ -1,0 +1,207 @@
+package ru.dreadblade.czarbank.api.controller;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.client.ExpectedCount;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+import ru.dreadblade.czarbank.api.model.response.external.CbrExchangeRatesResponseDTO;
+import ru.dreadblade.czarbank.domain.ExchangeRate;
+import ru.dreadblade.czarbank.repository.CurrencyRepository;
+import ru.dreadblade.czarbank.repository.ExchangeRateRepository;
+import ru.dreadblade.czarbank.service.task.FetchExchangeRatesFromCbrTask;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+@SpringBootTest(properties = { "czar-bank.currency.exchange-rate.update-rate-in-millis=5000" })
+@DisplayName("ExchangeRate Integration Tests")
+@Sql(value = { "/user/users-insertion.sql", "/bank-account/bank-accounts-insertion.sql" }, executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(value = { "/bank-account/bank-accounts-deletion.sql", "/user/users-deletion.sql" }, executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+public class ScheduledTasksIntegrationTests extends BaseIntegrationTest {
+    private static final String CBR_EXCHANGE_RATE_API_URL = "https://www.cbr.ru/scripts/XML_daily.asp";
+
+    @Autowired
+    RestTemplate restTemplate;
+
+    @Autowired
+    ExchangeRateRepository exchangeRateRepository;
+
+    @Autowired
+    CurrencyRepository currencyRepository;
+
+    @Autowired
+    FetchExchangeRatesFromCbrTask fetchExchangeRatesFromCbrTask;
+
+    @Nested
+    @DisplayName("Fetch exchange rates from the Central Bank Of Russia Tests")
+    class fetchExchangeRatesFromCentralBankOfRussia {
+        @Test
+        @Rollback
+        void fetchExchangeRatesFromCentralBankOfRussia_isSuccessful() {
+            Assertions.assertThat(fetchExchangeRatesFromCbrTask.execute()).isTrue();
+        }
+
+        @Test
+        @Rollback
+        void fetchExchangeRatesFromCentralBankOfRussia_responseDateIsBeforeToday_isSuccessful() throws Exception {
+            MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+
+            List<CbrExchangeRatesResponseDTO.CbrExchangeRateResponseDTO> rates = List.of(
+                    CbrExchangeRatesResponseDTO.CbrExchangeRateResponseDTO.builder()
+                            .currencyCode(currencyRepository.findById(BASE_CURRENCY_ID + 2L).orElseThrow().getCode())
+                            .nominal(1L)
+                            .rate(new BigDecimal("12.34567"))
+                            .build(),
+                    CbrExchangeRatesResponseDTO.CbrExchangeRateResponseDTO.builder()
+                            .currencyCode(currencyRepository.findById(BASE_CURRENCY_ID + 3L).orElseThrow().getCode())
+                            .nominal(1L)
+                            .rate(new BigDecimal("123.45678"))
+                            .build()
+            );
+
+            LocalDate yesterday = LocalDate.now().minusDays(1);
+
+            String responseBody = objectMapper.writeValueAsString(CbrExchangeRatesResponseDTO.builder()
+                    .rates(rates)
+                    .date(yesterday)
+                    .build());
+
+            mockServer.expect(ExpectedCount.once(), requestTo(new URI(CBR_EXCHANGE_RATE_API_URL)))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withStatus(HttpStatus.OK)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .body(responseBody));
+
+            Assertions.assertThat(fetchExchangeRatesFromCbrTask.execute()).isTrue();
+
+            List<ExchangeRate> addedRates = exchangeRateRepository.findAllLatest();
+
+            Assertions.assertThat(addedRates).isNotEmpty();
+            Assertions.assertThat(addedRates.get(0).getExchangeRate())
+                    .isEqualTo(rates.get(0).getRate().setScale(2, RoundingMode.UP));
+            Assertions.assertThat(addedRates.get(0).getCurrency().getCode())
+                    .isEqualTo(rates.get(0).getCurrencyCode());
+            Assertions.assertThat(addedRates.get(1).getExchangeRate())
+                    .isEqualTo(rates.get(1).getRate().setScale(2, RoundingMode.UP));
+            Assertions.assertThat(addedRates.get(1).getCurrency().getCode())
+                    .isEqualTo(rates.get(1).getCurrencyCode());
+        }
+
+        @Test
+        @Rollback
+        void fetchExchangeRatesFromCentralBankOfRussia_rewritesExistingData_isSuccessful() throws Exception {
+            List<ExchangeRate> addedRates = exchangeRateRepository.findAllLatest();
+
+            Assertions.assertThat(addedRates).isNotEmpty();
+
+            MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+
+            List<CbrExchangeRatesResponseDTO.CbrExchangeRateResponseDTO> rates = List.of(
+                    CbrExchangeRatesResponseDTO.CbrExchangeRateResponseDTO.builder()
+                            .currencyCode(currencyRepository.findById(BASE_CURRENCY_ID + 2L).orElseThrow().getCode())
+                            .nominal(1L)
+                            .rate(new BigDecimal("1234.56789"))
+                            .build(),
+                    CbrExchangeRatesResponseDTO.CbrExchangeRateResponseDTO.builder()
+                            .currencyCode(currencyRepository.findById(BASE_CURRENCY_ID + 3L).orElseThrow().getCode())
+                            .nominal(1L)
+                            .rate(new BigDecimal("1234.56789"))
+                            .build()
+            );
+
+            LocalDate expectedDate = LocalDate.now();
+
+            String responseBody = objectMapper.writeValueAsString(CbrExchangeRatesResponseDTO.builder()
+                    .rates(rates)
+                    .date(expectedDate)
+                    .build());
+
+            mockServer.expect(ExpectedCount.once(), requestTo(new URI(CBR_EXCHANGE_RATE_API_URL)))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withStatus(HttpStatus.OK)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .body(responseBody));
+
+            Assertions.assertThat(fetchExchangeRatesFromCbrTask.execute()).isTrue();
+
+            addedRates = exchangeRateRepository.findAllLatest();
+
+            Assertions.assertThat(addedRates).isNotEmpty();
+            Assertions.assertThat(addedRates.get(0).getExchangeRate())
+                    .isEqualTo(rates.get(0).getRate().setScale(2, RoundingMode.UP));
+            Assertions.assertThat(addedRates.get(0).getCurrency().getCode())
+                    .isEqualTo(rates.get(0).getCurrencyCode());
+            Assertions.assertThat(addedRates.get(1).getExchangeRate())
+                    .isEqualTo(rates.get(1).getRate().setScale(2, RoundingMode.UP));
+            Assertions.assertThat(addedRates.get(1).getCurrency().getCode())
+                    .isEqualTo(rates.get(1).getCurrencyCode());
+        }
+
+        @Test
+        void fetchExchangeRatesFromCentralBankOfRussia_responseStatusIsInvalid_isFailed() throws Exception {
+            MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+
+            String responseBody = objectMapper.writeValueAsString(new CbrExchangeRatesResponseDTO());
+
+            mockServer.expect(ExpectedCount.once(), requestTo(new URI(CBR_EXCHANGE_RATE_API_URL)))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .body(responseBody));
+
+            Assertions.assertThat(fetchExchangeRatesFromCbrTask.execute()).isFalse();
+        }
+
+        @Test
+        void fetchExchangeRatesFromCentralBankOfRussia_ratesIsNull_isFailed() throws Exception {
+            MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+
+            String responseBody = objectMapper.writeValueAsString(CbrExchangeRatesResponseDTO.builder()
+                    .rates(null)
+                    .build());
+
+            mockServer.expect(ExpectedCount.once(), requestTo(new URI(CBR_EXCHANGE_RATE_API_URL)))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .body(responseBody));
+
+            Assertions.assertThat(fetchExchangeRatesFromCbrTask.execute()).isFalse();
+        }
+
+        @Test
+        void fetchExchangeRatesFromCentralBankOfRussia_ratesIsEmpty_isFailed() throws Exception {
+            MockRestServiceServer mockServer = MockRestServiceServer.createServer(restTemplate);
+
+            String responseBody = objectMapper.writeValueAsString(CbrExchangeRatesResponseDTO.builder()
+                    .rates(new ArrayList<>())
+                    .build());
+
+            mockServer.expect(ExpectedCount.once(), requestTo(new URI(CBR_EXCHANGE_RATE_API_URL)))
+                    .andExpect(method(HttpMethod.GET))
+                    .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .body(responseBody));
+
+            Assertions.assertThat(fetchExchangeRatesFromCbrTask.execute()).isFalse();
+        }
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -6,6 +6,9 @@ spring:
       ddl-auto: create-drop
 
 czar-bank:
+  currency:
+    exchange-rate:
+      update-rate-in-millis: 3600000
   security:
     json-web-token:
       access-token:

--- a/src/test/resources/bank-account/bank-accounts-deletion.sql
+++ b/src/test/resources/bank-account/bank-accounts-deletion.sql
@@ -1,3 +1,4 @@
 delete from bank_account;
+delete from exchange_rate;
 delete from currency;
 delete from bank_account_type;

--- a/src/test/resources/bank-account/bank-accounts-insertion.sql
+++ b/src/test/resources/bank-account/bank-accounts-insertion.sql
@@ -1,4 +1,5 @@
 delete from bank_account;
+delete from exchange_rate;
 delete from currency;
 delete from bank_account_type;
 

--- a/src/test/resources/bank-account/bank-accounts-insertion.sql
+++ b/src/test/resources/bank-account/bank-accounts-insertion.sql
@@ -13,10 +13,22 @@ insert into currency (id, code, symbol) values (26, 'RUB', '₽');
 insert into currency (id, code, symbol) values (27, 'USD', '$');
 insert into currency (id, code, symbol) values (28, 'EUR', '€');
 
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (29, 15000, false, '39903336089073190794', 19, 26, 21);
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (30, 5000, false, '33390474811219980161', 20, 26, 22);
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (31, 2000, false, '38040432731497506063', 18, 26, 23);
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (32, 500, false, '36264421013439107929', 20, 26, 24);
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (33, 1500, false, '32541935657215432384', 19, 26, 24);
+insert into exchange_rate (id, date, exchange_rate, currency_id)
+values (29, '2021-09-01', 73.28, 27),
+       (30, '2021-09-01', 86.67, 28),
+       (31, '2021-09-02', 73.19, 27),
+       (32, '2021-09-02', 86.39, 28),
+       (33, '2021-09-03', 72.85, 27),
+       (34, '2021-09-03', 86.30, 28),
+       (35, '2021-09-04', 72.85, 27),
+       (36, '2021-09-04', 86.54, 28),
+       (37, '2021-09-05', 72.85, 27),
+       (38, '2021-09-05', 86.54, 28);
 
-alter sequence hibernate_sequence restart 34;
+insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (39, 15000, false, '39903336089073190794', 19, 26, 21);
+insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (40, 5000, false, '33390474811219980161', 20, 26, 22);
+insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (41, 2000, false, '38040432731497506063', 18, 26, 23);
+insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (42, 500, false, '36264421013439107929', 20, 26, 24);
+insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (43, 1500, false, '32541935657215432384', 19, 26, 24);
+
+alter sequence hibernate_sequence restart 44;

--- a/src/test/resources/transaction/transactions-insertion.sql
+++ b/src/test/resources/transaction/transactions-insertion.sql
@@ -1,8 +1,8 @@
 delete from transaction;
 
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (34, 1000, now(), 29, 30);
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (35, 2500, now(), 30, 31);
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (36, 1500, now(), 31, 32);
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (37, 250, now(), 32, 33);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (44, 1000, now(), 39, 40);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (45, 2500, now(), 40, 41);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (46, 1500, now(), 41, 42);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (47, 250, now(), 42, 43);
 
-alter sequence hibernate_sequence restart 38;
+alter sequence hibernate_sequence restart 48;


### PR DESCRIPTION
Added new API endpoint for currency exchange rates: `/api/currencies/exchange-rates`
`/latest` -  to find out the latest exchange rates
`/historical/{date}` - to get exchange rates for a specific date
`/time-series?start-date={startDate}&end-date={endDate}` - to get all exchange rates for the period

A new entity has been added - `ExchangeRate`, which contains the currency, the exchange rate (against the Russian Ruble) and the date on which the exchange rate is actual.