### PR TITLE
Added cross-currency transactions

### DIFF
--- a/src/main/java/ru/dreadblade/czarbank/api/model/response/CzarBankErrorResponseDTO.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/model/response/CzarBankErrorResponseDTO.java
@@ -2,6 +2,7 @@ package ru.dreadblade.czarbank.api.model.response;
 
 import lombok.*;
 
+import java.time.Instant;
 import java.util.Date;
 
 @Getter
@@ -11,7 +12,7 @@ import java.util.Date;
 @AllArgsConstructor
 public class CzarBankErrorResponseDTO {
     @Builder.Default
-    private Date timestamp = new Date();
+    private Instant timestamp = Instant.now();
     private int status;
     private String error;
     private String message;

--- a/src/main/java/ru/dreadblade/czarbank/api/model/response/TransactionResponseDTO.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/model/response/TransactionResponseDTO.java
@@ -14,6 +14,7 @@ public class TransactionResponseDTO {
     private Long id;
     private Instant datetime;
     private BigDecimal amount;
+    private BigDecimal receivedAmount;
     private BankAccountResponseDTO sourceBankAccount;
     private BankAccountResponseDTO destinationBankAccount;
 }

--- a/src/main/java/ru/dreadblade/czarbank/domain/BankAccountType.java
+++ b/src/main/java/ru/dreadblade/czarbank/domain/BankAccountType.java
@@ -22,4 +22,6 @@ public class BankAccountType {
     private String name;
 
     private BigDecimal transactionCommission;
+
+    private BigDecimal currencyExchangeCommission;
 }

--- a/src/main/java/ru/dreadblade/czarbank/domain/Transaction.java
+++ b/src/main/java/ru/dreadblade/czarbank/domain/Transaction.java
@@ -25,6 +25,9 @@ public class Transaction {
     @Column(updatable = false)
     private BigDecimal amount;
 
+    @Column(updatable = false)
+    private BigDecimal receivedAmount;
+
     @ManyToOne(fetch = FetchType.EAGER)
     private BankAccount sourceBankAccount;
 

--- a/src/main/java/ru/dreadblade/czarbank/domain/TransactionType.java
+++ b/src/main/java/ru/dreadblade/czarbank/domain/TransactionType.java
@@ -1,8 +1,0 @@
-package ru.dreadblade.czarbank.domain;
-
-public enum TransactionType {
-    TRANSFER,
-    DEPOSIT,
-    WITHDRAW,
-    PAYMENT,
-}

--- a/src/main/java/ru/dreadblade/czarbank/domain/TransactionType.java
+++ b/src/main/java/ru/dreadblade/czarbank/domain/TransactionType.java
@@ -1,0 +1,8 @@
+package ru.dreadblade.czarbank.domain;
+
+public enum TransactionType {
+    TRANSFER,
+    DEPOSIT,
+    WITHDRAW,
+    PAYMENT,
+}

--- a/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
@@ -8,7 +8,7 @@ public enum ExceptionMessage {
     BANK_ACCOUNT_TYPE_NOT_FOUND("Bank account type doesn't exist", HttpStatus.NOT_FOUND),
     CURRENCY_NOT_FOUND("Currency doesn't exist", HttpStatus.NOT_FOUND),
     LATEST_EXCHANGE_RATES_NOT_FOUND("Error while loading the latest currency rates", HttpStatus.INTERNAL_SERVER_ERROR),
-    EXCHANGE_RATES_AT_DATE_NOT_FOUND("No exchange rates found for the date ", HttpStatus.NOT_FOUND),
+    EXCHANGE_RATES_AT_DATE_NOT_FOUND("No exchange rates found for the date", HttpStatus.NOT_FOUND),
     BANK_ACCOUNT_NOT_FOUND("Bank account doesn't exist", HttpStatus.NOT_FOUND),
     PERMISSION_NOT_FOUND("Permission doesn't exist", HttpStatus.NOT_FOUND),
     ROLE_NOT_FOUND("Role doesn't exist", HttpStatus.NOT_FOUND),

--- a/src/main/java/ru/dreadblade/czarbank/service/TransactionService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/TransactionService.java
@@ -1,6 +1,5 @@
 package ru.dreadblade.czarbank.service;
 
-import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import ru.dreadblade.czarbank.api.model.request.TransactionRequestDTO;
@@ -20,11 +19,13 @@ public class TransactionService {
 
     private final TransactionRepository transactionRepository;
     private final BankAccountRepository bankAccountRepository;
+    private final CurrencyService currencyService;
 
     @Autowired
-    public TransactionService(TransactionRepository transactionRepository, BankAccountRepository bankAccountRepository) {
+    public TransactionService(TransactionRepository transactionRepository, BankAccountRepository bankAccountRepository, CurrencyService currencyService) {
         this.transactionRepository = transactionRepository;
         this.bankAccountRepository = bankAccountRepository;
+        this.currencyService = currencyService;
     }
 
     public List<Transaction> findAll() {
@@ -44,33 +45,40 @@ public class TransactionService {
         BankAccount source = bankAccountRepository.findByNumber(transactionRequest.getSourceBankAccountNumber())
                 .orElseThrow(() -> new CzarBankException(ExceptionMessage.BANK_ACCOUNT_NOT_FOUND));
 
-        BigDecimal transactionAmount = transactionRequest.getAmount();
-
-        if (source.getBalance().compareTo(transactionAmount) < 0) {
-            throw new CzarBankException(ExceptionMessage.NOT_ENOUGH_BALANCE);
-        }
-
         BankAccount destination = bankAccountRepository.findByNumber(transactionRequest.getDestinationBankAccountNumber())
                 .orElseThrow(() -> new CzarBankException(ExceptionMessage.BANK_ACCOUNT_NOT_FOUND));
 
-        if (!source.getUsedCurrency().equals(destination.getUsedCurrency())) {
-            throw new NotImplementedException("Currency exchange has not yet been implemented");
-        }
-
-        Transaction transaction = Transaction.builder()
-                .amount(transactionAmount)
-                .sourceBankAccount(source)
-                .destinationBankAccount(destination)
-                .build();
-
+        BigDecimal transactionAmount = transactionRequest.getAmount();
         BigDecimal transactionCommissionAmount = transactionAmount.multiply(source.getBankAccountType()
                 .getTransactionCommission());
 
         BigDecimal transactionAmountWithCommission = transactionAmount.add(transactionCommissionAmount);
 
+        if (!source.getUsedCurrency().equals(destination.getUsedCurrency())) {
+            transactionCommissionAmount = transactionAmount.multiply(source.getBankAccountType().getCurrencyExchangeCommission());
+
+            transactionAmountWithCommission = transactionAmountWithCommission.add(transactionCommissionAmount);
+        }
+
+        if (source.getBalance().compareTo(transactionAmountWithCommission) < 0) {
+            throw new CzarBankException(ExceptionMessage.NOT_ENOUGH_BALANCE);
+        }
+
+        Transaction transaction = Transaction.builder()
+                .amount(transactionAmount)
+                .receivedAmount(transactionAmount)
+                .sourceBankAccount(source)
+                .destinationBankAccount(destination)
+                .build();
+
         source.setBalance(source.getBalance().subtract(transactionAmountWithCommission));
 
-        destination.setBalance(destination.getBalance().add(transactionAmount));
+        if (!source.getUsedCurrency().equals(destination.getUsedCurrency())) {
+            transaction.setReceivedAmount(currencyService.exchangeCurrency(source.getUsedCurrency(), transactionAmount,
+                    destination.getUsedCurrency()));
+        }
+
+        destination.setBalance(destination.getBalance().add(transaction.getReceivedAmount()));
 
         return transactionRepository.save(transaction);
     }

--- a/src/main/java/ru/dreadblade/czarbank/service/task/FetchExchangeRatesFromCbrTask.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/task/FetchExchangeRatesFromCbrTask.java
@@ -65,7 +65,7 @@ public class FetchExchangeRatesFromCbrTask implements Task {
                 .filter(dto -> usedCurrencies.contains(dto.getCurrencyCode()))
                 .map(dto -> {
                     if (dto.getNominal() > 1) {
-                        dto.setRate(dto.getRate().divide(BigDecimal.valueOf(dto.getNominal()), RoundingMode.UP));
+                        dto.setRate(dto.getRate().divide(BigDecimal.valueOf(dto.getNominal()), RoundingMode.HALF_EVEN));
                     }
 
                     Currency currency = currencyRepository.findByCode(dto.getCurrencyCode())

--- a/src/main/java/ru/dreadblade/czarbank/util/BigDecimalDeserializer.java
+++ b/src/main/java/ru/dreadblade/czarbank/util/BigDecimalDeserializer.java
@@ -1,7 +1,6 @@
 package ru.dreadblade.czarbank.util;
 
 import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 
@@ -10,7 +9,7 @@ import java.math.BigDecimal;
 
 public class BigDecimalDeserializer extends JsonDeserializer<BigDecimal> {
     @Override
-    public BigDecimal deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+    public BigDecimal deserialize(JsonParser p, DeserializationContext ctx) throws IOException {
         String rawValue = p.getValueAsString().replace(",", ".");
 
         return new BigDecimal(rawValue);

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/BaseIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/BaseIntegrationTest.java
@@ -39,9 +39,9 @@ public abstract class BaseIntegrationTest {
     protected final long BASE_USER_ID = 15L;
     protected final long BASE_BANK_ACCOUNT_TYPE_ID = 20L;
     protected final long BASE_CURRENCY_ID = 25L;
-    protected final long BASE_EXCHANGE_RATE_ID = 28L;
-    protected final long BASE_BANK_ACCOUNT_ID = 38L;
-    protected final long BASE_TRANSACTION_ID = 43L;
+    protected final long BASE_EXCHANGE_RATE_ID = 30L;
+    protected final long BASE_BANK_ACCOUNT_ID = 45L;
+    protected final long BASE_TRANSACTION_ID = 50L;
 
     @Autowired
     WebApplicationContext webApplicationContext;

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/CurrencyIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/CurrencyIntegrationTest.java
@@ -13,11 +13,18 @@ import org.springframework.test.context.jdbc.Sql;
 import ru.dreadblade.czarbank.api.mapper.CurrencyMapper;
 import ru.dreadblade.czarbank.api.model.request.CurrencyRequestDTO;
 import ru.dreadblade.czarbank.api.model.response.CurrencyResponseDTO;
+import ru.dreadblade.czarbank.domain.Currency;
 import ru.dreadblade.czarbank.exception.ExceptionMessage;
 import ru.dreadblade.czarbank.repository.BankAccountRepository;
 import ru.dreadblade.czarbank.repository.CurrencyRepository;
 import ru.dreadblade.czarbank.repository.ExchangeRateRepository;
+import ru.dreadblade.czarbank.repository.security.UserRepository;
+import ru.dreadblade.czarbank.service.BankAccountService;
+import ru.dreadblade.czarbank.service.CurrencyService;
+import ru.dreadblade.czarbank.service.ExchangeRateService;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -35,16 +42,28 @@ public class CurrencyIntegrationTest extends BaseIntegrationTest {
     public static final String CURRENCIES_API_URL = "/api/currencies";
 
     @Autowired
+    BankAccountService bankAccountService;
+
+    @Autowired
     BankAccountRepository bankAccountRepository;
 
     @Autowired
+    ExchangeRateService exchangeRateService;
+
+    @Autowired
     ExchangeRateRepository exchangeRateRepository;
+
+    @Autowired
+    CurrencyService currencyService;
 
     @Autowired
     CurrencyRepository currencyRepository;
 
     @Autowired
     CurrencyMapper currencyMapper;
+
+    @Autowired
+    UserRepository userRepository;
 
     @Nested
     @DisplayName("findAll() Tests")
@@ -166,6 +185,191 @@ public class CurrencyIntegrationTest extends BaseIntegrationTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.message")
                             .value(ExceptionMessage.UNSUPPORTED_CURRENCY.getMessage()));
+        }
+    }
+
+    @Nested
+    @DisplayName("exchangeCurrency() Tests")
+    class exchangeCurrencyTests {
+        @Test
+        void exchangeCurrency_fromRubToUsd_isSuccessful() {
+            Currency sourceCurrency = currencyRepository.findByCode("RUB").orElseThrow();
+            Currency targetCurrency = currencyRepository.findByCode("USD").orElseThrow();
+
+            Assertions.assertThat(sourceCurrency.getCode()).isNotEqualTo(targetCurrency.getCode());
+
+            BigDecimal exchangeRate = exchangeRateService.findAllLatest().stream()
+                    .filter(rate -> rate.getCurrency().getCode().equals(targetCurrency.getCode()))
+                    .findFirst().orElseThrow()
+                    .getExchangeRate();
+
+            BigDecimal amountInRub = new BigDecimal(10000L);
+
+            BigDecimal amountInUsd = currencyService.exchangeCurrency(sourceCurrency, amountInRub, targetCurrency);
+
+            Assertions.assertThat(amountInUsd).isEqualByComparingTo(amountInRub.divide(exchangeRate, RoundingMode.HALF_EVEN));
+        }
+
+        @Test
+        void exchangeCurrency_fromUsdToRub_isSuccessful() {
+            Currency sourceCurrency = currencyRepository.findByCode("USD").orElseThrow();
+            Currency targetCurrency = currencyRepository.findByCode("RUB").orElseThrow();
+
+            Assertions.assertThat(sourceCurrency.getCode()).isNotEqualTo(targetCurrency.getCode());
+
+            BigDecimal exchangeRate = exchangeRateService.findAllLatest().stream()
+                    .filter(rate -> rate.getCurrency().getCode().equals(sourceCurrency.getCode()))
+                    .findFirst().orElseThrow()
+                    .getExchangeRate();
+
+            BigDecimal amountInUsd = new BigDecimal(100L);
+
+            BigDecimal amountInRub = currencyService.exchangeCurrency(sourceCurrency, amountInUsd, targetCurrency);
+
+            Assertions.assertThat(amountInRub).isEqualByComparingTo(amountInUsd.multiply(exchangeRate));
+        }
+
+        @Test
+        void exchangeCurrency_fromRubToJpy_isSuccessful() {
+            Currency sourceCurrency = currencyRepository.findByCode("RUB").orElseThrow();
+            Currency targetCurrency = currencyRepository.findByCode("JPY").orElseThrow();
+
+            Assertions.assertThat(sourceCurrency.getCode()).isNotEqualTo(targetCurrency.getCode());
+
+            BigDecimal exchangeRate = exchangeRateService.findAllLatest().stream()
+                    .filter(rate -> rate.getCurrency().getCode().equals(targetCurrency.getCode()))
+                    .findFirst().orElseThrow()
+                    .getExchangeRate();
+
+            BigDecimal amountInRub = new BigDecimal(10000L);
+            BigDecimal amountInJpy = currencyService.exchangeCurrency(sourceCurrency, amountInRub, targetCurrency);
+
+            Assertions.assertThat(amountInJpy).isEqualByComparingTo(amountInRub.divide(exchangeRate, RoundingMode.HALF_EVEN));
+        }
+
+        @Test
+        void exchangeCurrency_fromJpyToRub_isSuccessful() {
+            Currency sourceCurrency = currencyRepository.findByCode("JPY").orElseThrow();
+            Currency targetCurrency = currencyRepository.findByCode("RUB").orElseThrow();
+
+            Assertions.assertThat(sourceCurrency.getCode()).isNotEqualTo(targetCurrency.getCode());
+
+            BigDecimal exchangeRate = exchangeRateService.findAllLatest().stream()
+                    .filter(rate -> rate.getCurrency().getCode().equals(sourceCurrency.getCode()))
+                    .findFirst().orElseThrow()
+                    .getExchangeRate();
+
+            BigDecimal amountInJpy = new BigDecimal(10000L);
+
+            BigDecimal amountInRub = currencyService.exchangeCurrency(sourceCurrency, amountInJpy, targetCurrency);
+
+            Assertions.assertThat(amountInRub).isEqualByComparingTo(amountInJpy.multiply(exchangeRate));
+        }
+
+        @Test
+        void exchangeCurrency_fromRubToRub_isSuccessful() {
+            Currency sourceCurrency = currencyRepository.findByCode("RUB").orElseThrow();
+            Currency targetCurrency = currencyRepository.findByCode("RUB").orElseThrow();
+
+            Assertions.assertThat(sourceCurrency.getCode()).isEqualTo(targetCurrency.getCode());
+
+            BigDecimal amountInRub = new BigDecimal(10000L);
+
+            BigDecimal exchangedAmountInRub = currencyService.exchangeCurrency(sourceCurrency, amountInRub, targetCurrency);
+
+            Assertions.assertThat(amountInRub).isEqualByComparingTo(exchangedAmountInRub);
+        }
+
+        @Test
+        void exchangeCurrency_fromUsdToUsd_isSuccessful() {
+            Currency sourceCurrency = currencyRepository.findByCode("USD").orElseThrow();
+            Currency targetCurrency = currencyRepository.findByCode("USD").orElseThrow();
+
+            Assertions.assertThat(sourceCurrency.getCode()).isEqualTo(targetCurrency.getCode());
+
+            BigDecimal amountInUsd = new BigDecimal(10000L);
+
+            BigDecimal exchangedAmountInUsd = currencyService.exchangeCurrency(sourceCurrency, amountInUsd, targetCurrency);
+
+            Assertions.assertThat(amountInUsd).isEqualByComparingTo(exchangedAmountInUsd);
+        }
+
+        @Test
+        void exchangeCurrency_fromEurToUsd_isSuccessful() {
+            Currency sourceCurrency = currencyRepository.findByCode("EUR").orElseThrow();
+            Currency targetCurrency = currencyRepository.findByCode("USD").orElseThrow();
+
+            Assertions.assertThat(sourceCurrency.getCode()).isNotEqualTo(targetCurrency.getCode());
+
+            BigDecimal exchangeRateToRub = exchangeRateService.findAllLatest().stream()
+                    .filter(rate -> rate.getCurrency().getCode().equals(sourceCurrency.getCode()))
+                    .findFirst().orElseThrow()
+                    .getExchangeRate();
+
+            BigDecimal exchangeRateFromRub = exchangeRateService.findAllLatest().stream()
+                    .filter(rate -> rate.getCurrency().getCode().equals(targetCurrency.getCode()))
+                    .findFirst().orElseThrow()
+                    .getExchangeRate();
+
+            BigDecimal amountInEur = new BigDecimal(10000L);
+
+            BigDecimal amountInUsd = currencyService.exchangeCurrency(sourceCurrency, amountInEur, targetCurrency);
+
+            BigDecimal expected = amountInEur.multiply(exchangeRateToRub).divide(exchangeRateFromRub, RoundingMode.HALF_EVEN);
+
+            Assertions.assertThat(amountInUsd).isEqualByComparingTo(expected);
+        }
+
+        @Test
+        void exchangeCurrency_fromJpyToUsd_isSuccessful() {
+            Currency sourceCurrency = currencyRepository.findByCode("JPY").orElseThrow();
+            Currency targetCurrency = currencyRepository.findByCode("USD").orElseThrow();
+
+            Assertions.assertThat(sourceCurrency.getCode()).isNotEqualTo(targetCurrency.getCode());
+
+            BigDecimal exchangeRateToRub = exchangeRateService.findAllLatest().stream()
+                    .filter(rate -> rate.getCurrency().getCode().equals(sourceCurrency.getCode()))
+                    .findFirst().orElseThrow()
+                    .getExchangeRate();
+
+            BigDecimal exchangeRateFromRub = exchangeRateService.findAllLatest().stream()
+                    .filter(rate -> rate.getCurrency().getCode().equals(targetCurrency.getCode()))
+                    .findFirst().orElseThrow()
+                    .getExchangeRate();
+
+            BigDecimal amountInJpy = new BigDecimal(10000L);
+
+            BigDecimal amountInUsd = currencyService.exchangeCurrency(sourceCurrency, amountInJpy, targetCurrency);
+
+            BigDecimal expected = amountInJpy.multiply(exchangeRateToRub).divide(exchangeRateFromRub, RoundingMode.HALF_EVEN);
+
+            Assertions.assertThat(amountInUsd).isEqualByComparingTo(expected);
+        }
+
+        @Test
+        void exchangeCurrency_fromUsdToJpy_isSuccessful() {
+            Currency sourceCurrency = currencyRepository.findByCode("USD").orElseThrow();
+            Currency targetCurrency = currencyRepository.findByCode("JPY").orElseThrow();
+
+            Assertions.assertThat(sourceCurrency.getCode()).isNotEqualTo(targetCurrency.getCode());
+
+            BigDecimal exchangeRateToRub = exchangeRateService.findAllLatest().stream()
+                    .filter(rate -> rate.getCurrency().getCode().equals(sourceCurrency.getCode()))
+                    .findFirst().orElseThrow()
+                    .getExchangeRate();
+
+            BigDecimal exchangeRateFromRub = exchangeRateService.findAllLatest().stream()
+                    .filter(rate -> rate.getCurrency().getCode().equals(targetCurrency.getCode()))
+                    .findFirst().orElseThrow()
+                    .getExchangeRate();
+
+            BigDecimal amountInUsd = new BigDecimal(10000L);
+
+            BigDecimal amountInJpy = currencyService.exchangeCurrency(sourceCurrency, amountInUsd, targetCurrency);
+
+            BigDecimal expected = amountInUsd.multiply(exchangeRateToRub).divide(exchangeRateFromRub, RoundingMode.HALF_EVEN);
+
+            Assertions.assertThat(amountInJpy).isEqualByComparingTo(expected);
         }
     }
 }

--- a/src/test/resources/bank-account/bank-accounts-insertion.sql
+++ b/src/test/resources/bank-account/bank-accounts-insertion.sql
@@ -3,11 +3,12 @@ delete from exchange_rate;
 delete from currency;
 delete from bank_account_type;
 
-insert into bank_account_type (id, name, transaction_commission) values (21, 'Czar', 0.01);
-insert into bank_account_type (id, name, transaction_commission) values (22, 'Nobleman', 0.02);
-insert into bank_account_type (id, name, transaction_commission) values (23, 'Junker', 0.03);
-insert into bank_account_type (id, name, transaction_commission) values (24, 'Standard', 0.04);
-insert into bank_account_type (id, name, transaction_commission) values (25, 'Unused account type', 0.10);
+insert into bank_account_type (id, name, transaction_commission, currency_exchange_commission)
+values (21, 'Czar', 0.01, 0.01),
+       (22, 'Nobleman', 0.02, 0.02),
+       (23, 'Junker', 0.03, 0.03),
+       (24, 'Standard', 0.04, 0.04),
+       (25, 'Unused account type', 0.10, 0.20);
 
 insert into currency (id, code, symbol)
 values (26, 'RUB', '₽'),
@@ -34,10 +35,11 @@ values (31, '2021-09-01', 73.28, 27),
        (44, '2021-09-04', 0.67, 29),
        (45, '2021-09-05', 0.67, 29);
 
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (46, 15000, false, '39903336089073190794', 19, 26, 21);
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (47, 5000, false, '33390474811219980161', 20, 26, 22);
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (48, 2000, false, '38040432731497506063', 18, 26, 23);
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (49, 500, false, '36264421013439107929', 20, 26, 24);
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (50, 1500, false, '32541935657215432384', 19, 26, 24);
+insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id)
+values (46, 15000, false, '39903336089073190794', 19, 26, 21),
+       (47, 5000, false, '33390474811219980161', 20, 26, 22),
+       (48, 2000, false, '38040432731497506063', 18, 26, 23),
+       (49, 500, false, '36264421013439107929', 20, 26, 24),
+       (50, 1500, false, '32541935657215432384', 19, 26, 24);
 
 alter sequence hibernate_sequence restart 51;

--- a/src/test/resources/bank-account/bank-accounts-insertion.sql
+++ b/src/test/resources/bank-account/bank-accounts-insertion.sql
@@ -9,26 +9,35 @@ insert into bank_account_type (id, name, transaction_commission) values (23, 'Ju
 insert into bank_account_type (id, name, transaction_commission) values (24, 'Standard', 0.04);
 insert into bank_account_type (id, name, transaction_commission) values (25, 'Unused account type', 0.10);
 
-insert into currency (id, code, symbol) values (26, 'RUB', '₽');
-insert into currency (id, code, symbol) values (27, 'USD', '$');
-insert into currency (id, code, symbol) values (28, 'EUR', '€');
+insert into currency (id, code, symbol)
+values (26, 'RUB', '₽'),
+       (27, 'USD', '$'),
+       (28, 'EUR', '€'),
+       (29, 'JPY', '¥');
 
 insert into exchange_rate (id, date, exchange_rate, currency_id)
-values (29, '2021-09-01', 73.28, 27),
-       (30, '2021-09-01', 86.67, 28),
-       (31, '2021-09-02', 73.19, 27),
-       (32, '2021-09-02', 86.39, 28),
+values (31, '2021-09-01', 73.28, 27),
+       (32, '2021-09-02', 73.19, 27),
        (33, '2021-09-03', 72.85, 27),
-       (34, '2021-09-03', 86.30, 28),
-       (35, '2021-09-04', 72.85, 27),
-       (36, '2021-09-04', 86.54, 28),
-       (37, '2021-09-05', 72.85, 27),
-       (38, '2021-09-05', 86.54, 28);
+       (34, '2021-09-04', 72.85, 27),
+       (35, '2021-09-05', 72.85, 27),
 
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (39, 15000, false, '39903336089073190794', 19, 26, 21);
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (40, 5000, false, '33390474811219980161', 20, 26, 22);
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (41, 2000, false, '38040432731497506063', 18, 26, 23);
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (42, 500, false, '36264421013439107929', 20, 26, 24);
-insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (43, 1500, false, '32541935657215432384', 19, 26, 24);
+       (36, '2021-09-01', 86.67, 28),
+       (37, '2021-09-02', 86.39, 28),
+       (38, '2021-09-03', 86.30, 28),
+       (39, '2021-09-04', 86.54, 28),
+       (40, '2021-09-05', 86.54, 28),
 
-alter sequence hibernate_sequence restart 44;
+       (41, '2021-09-01', 0.67, 29),
+       (42, '2021-09-02', 0.67, 29),
+       (43, '2021-09-03', 0.67, 29),
+       (44, '2021-09-04', 0.67, 29),
+       (45, '2021-09-05', 0.67, 29);
+
+insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (46, 15000, false, '39903336089073190794', 19, 26, 21);
+insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (47, 5000, false, '33390474811219980161', 20, 26, 22);
+insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (48, 2000, false, '38040432731497506063', 18, 26, 23);
+insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (49, 500, false, '36264421013439107929', 20, 26, 24);
+insert into bank_account (id, balance, is_closed, number, owner_id, used_currency_id, bank_account_type_id) values (50, 1500, false, '32541935657215432384', 19, 26, 24);
+
+alter sequence hibernate_sequence restart 51;

--- a/src/test/resources/transaction/transactions-insertion.sql
+++ b/src/test/resources/transaction/transactions-insertion.sql
@@ -1,8 +1,9 @@
 delete from transaction;
 
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (51, 1000, now(), 46, 47);
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (52, 2500, now(), 47, 48);
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (53, 1500, now(), 48, 49);
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (54, 250, now(), 49, 50);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id)
+values (51, 1000, now(), 46, 47),
+       (52, 2500, now(), 47, 48),
+       (53, 1500, now(), 48, 49),
+       (54, 250, now(), 49, 50);
 
 alter sequence hibernate_sequence restart 55;

--- a/src/test/resources/transaction/transactions-insertion.sql
+++ b/src/test/resources/transaction/transactions-insertion.sql
@@ -1,8 +1,8 @@
 delete from transaction;
 
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (44, 1000, now(), 39, 40);
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (45, 2500, now(), 40, 41);
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (46, 1500, now(), 41, 42);
-insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (47, 250, now(), 42, 43);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (51, 1000, now(), 46, 47);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (52, 2500, now(), 47, 48);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (53, 1500, now(), 48, 49);
+insert into transaction (id, amount, datetime, destination_bank_account_id, source_bank_account_id) values (54, 250, now(), 49, 50);
 
-alter sequence hibernate_sequence restart 48;
+alter sequence hibernate_sequence restart 55;


### PR DESCRIPTION
Cross-currency transactions are performed in the same way as transactions between the same currencies, with one exception - additional fee are charged for them.

Cross-currency transaction fee is calculated as: 
`fee = defaultTransactionCommission * currencyExchangeCommission`