### PR TITLE
Added email verification functionality

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-mail</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>com.auth0</groupId>

--- a/src/main/java/ru/dreadblade/czarbank/api/controller/security/AccountManagementController.java
+++ b/src/main/java/ru/dreadblade/czarbank/api/controller/security/AccountManagementController.java
@@ -1,0 +1,23 @@
+package ru.dreadblade.czarbank.api.controller.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import ru.dreadblade.czarbank.service.security.AccountManagementService;
+
+@RequestMapping("/api/")
+@RestController
+public class AccountManagementController {
+    private final AccountManagementService accountManagementService;
+
+    @Autowired
+    public AccountManagementController(AccountManagementService accountManagementService) {
+        this.accountManagementService = accountManagementService;
+    }
+
+    @ResponseStatus(HttpStatus.OK)
+    @GetMapping("/account-management/verify-email/{token}")
+    public void verifyEmail(@PathVariable String token) {
+        accountManagementService.verifyEmail(token);
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/domain/security/EmailVerificationToken.java
+++ b/src/main/java/ru/dreadblade/czarbank/domain/security/EmailVerificationToken.java
@@ -1,0 +1,29 @@
+package ru.dreadblade.czarbank.domain.security;
+
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import javax.persistence.*;
+import java.time.Instant;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+public class EmailVerificationToken {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(updatable = false)
+    private String emailVerificationToken;
+
+    @ManyToOne(fetch = FetchType.EAGER)
+    private User user;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private Instant createdAt;
+}

--- a/src/main/java/ru/dreadblade/czarbank/domain/security/User.java
+++ b/src/main/java/ru/dreadblade/czarbank/domain/security/User.java
@@ -38,6 +38,9 @@ public class User implements UserDetails {
     private Set<Role> roles;
 
     @Builder.Default
+    private boolean isEmailVerified = false;
+
+    @Builder.Default
     private boolean isAccountExpired = false;
 
     @Builder.Default

--- a/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
@@ -29,6 +29,7 @@ public enum ExceptionMessage {
     EMAIL_ADDRESS_ALREADY_VERIFIED("Email address already verified", HttpStatus.BAD_REQUEST),
     EMAIL_VERIFICATION_TOKEN_EXPIRED("We have sent a new email with a link to verify your account to " +
             "the email address you provided when you created your account", HttpStatus.BAD_REQUEST),
+    EMAIL_VERIFICATION_REQUIRED("Please check your email and follow the link to verify your email address", HttpStatus.UNAUTHORIZED),
 
     REFRESH_TOKEN_EXPIRED("Refresh token expired", HttpStatus.BAD_REQUEST),
     INVALID_REFRESH_TOKEN("Invalid refresh token", HttpStatus.BAD_REQUEST),

--- a/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
@@ -27,6 +27,8 @@ public enum ExceptionMessage {
     NOT_ENOUGH_BALANCE("Not enough balance", HttpStatus.BAD_REQUEST),
     UNSUPPORTED_CURRENCY("Currency is not supported", HttpStatus.BAD_REQUEST),
     EMAIL_ADDRESS_ALREADY_VERIFIED("Email address already verified", HttpStatus.BAD_REQUEST),
+    EMAIL_VERIFICATION_TOKEN_EXPIRED("We have sent a new email with a link to verify your account to " +
+            "the email address you provided when you created your account", HttpStatus.BAD_REQUEST),
 
     REFRESH_TOKEN_EXPIRED("Refresh token expired", HttpStatus.BAD_REQUEST),
     INVALID_REFRESH_TOKEN("Invalid refresh token", HttpStatus.BAD_REQUEST),

--- a/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
+++ b/src/main/java/ru/dreadblade/czarbank/exception/ExceptionMessage.java
@@ -26,10 +26,12 @@ public enum ExceptionMessage {
     BANK_ACCOUNT_TYPE_IN_USE("Bank account type in use", HttpStatus.BAD_REQUEST),
     NOT_ENOUGH_BALANCE("Not enough balance", HttpStatus.BAD_REQUEST),
     UNSUPPORTED_CURRENCY("Currency is not supported", HttpStatus.BAD_REQUEST),
+    EMAIL_ADDRESS_ALREADY_VERIFIED("Email address already verified", HttpStatus.BAD_REQUEST),
 
     REFRESH_TOKEN_EXPIRED("Refresh token expired", HttpStatus.BAD_REQUEST),
     INVALID_REFRESH_TOKEN("Invalid refresh token", HttpStatus.BAD_REQUEST),
-    INVALID_ACCESS_TOKEN("Invalid access token", HttpStatus.BAD_REQUEST);
+    INVALID_ACCESS_TOKEN("Invalid access token", HttpStatus.BAD_REQUEST),
+    INVALID_EMAIL_VERIFICATION_TOKEN("Invalid email verification token", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/ru/dreadblade/czarbank/repository/security/EmailVerificationTokenRepository.java
+++ b/src/main/java/ru/dreadblade/czarbank/repository/security/EmailVerificationTokenRepository.java
@@ -1,0 +1,14 @@
+package ru.dreadblade.czarbank.repository.security;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import ru.dreadblade.czarbank.domain.security.EmailVerificationToken;
+import ru.dreadblade.czarbank.domain.security.User;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface EmailVerificationTokenRepository extends JpaRepository<EmailVerificationToken, Long> {
+    Optional<EmailVerificationToken> findByEmailVerificationToken(String emailVerificationToken);
+    List<EmailVerificationToken> findAllByUser(User user);
+    boolean existsByEmailVerificationToken(String emailVerificationToken);
+}

--- a/src/main/java/ru/dreadblade/czarbank/security/config/SecurityConfiguration.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/config/SecurityConfiguration.java
@@ -36,7 +36,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .httpBasic().disable()
-                .formLogin().disable();
+                .formLogin().disable()
+                .rememberMe().disable()
+                .logout().disable();
     }
 
     @Bean

--- a/src/main/java/ru/dreadblade/czarbank/security/filter/JsonWebTokenAuthorizationFilter.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/filter/JsonWebTokenAuthorizationFilter.java
@@ -57,6 +57,10 @@ public class JsonWebTokenAuthorizationFilter extends OncePerRequestFilter {
 
         User user = accessTokenService.getUserFromToken(accessToken);
 
+        if (!user.isEmailVerified()) {
+            throw new CzarBankSecurityException(ExceptionMessage.EMAIL_VERIFICATION_REQUIRED);
+        }
+
         if (user.isAccountLocked()) {
             throw new LockedException("User's account is locked");
         }

--- a/src/main/java/ru/dreadblade/czarbank/security/service/AuthenticationService.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/service/AuthenticationService.java
@@ -44,13 +44,7 @@ public class AuthenticationService {
 
         Authentication authentication = authenticationManager.authenticate(token);
 
-        Object principal = authentication.getPrincipal();
-
-        if (!(principal instanceof User)) {
-            throw new IllegalStateException();
-        }
-
-        User user = (User) principal;
+        User user = (User) authentication.getPrincipal();
 
         if (!user.isEmailVerified()) {
             throw new CzarBankSecurityException(ExceptionMessage.EMAIL_VERIFICATION_REQUIRED);

--- a/src/main/java/ru/dreadblade/czarbank/security/service/AuthenticationService.java
+++ b/src/main/java/ru/dreadblade/czarbank/security/service/AuthenticationService.java
@@ -8,14 +8,13 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import ru.dreadblade.czarbank.api.model.request.security.AuthenticationRequestDTO;
-import ru.dreadblade.czarbank.domain.security.RefreshTokenSession;
 import ru.dreadblade.czarbank.domain.security.BlacklistedAccessToken;
+import ru.dreadblade.czarbank.domain.security.RefreshTokenSession;
 import ru.dreadblade.czarbank.domain.security.User;
-import ru.dreadblade.czarbank.exception.CzarBankException;
 import ru.dreadblade.czarbank.exception.CzarBankSecurityException;
 import ru.dreadblade.czarbank.exception.ExceptionMessage;
-import ru.dreadblade.czarbank.repository.security.RefreshTokenSessionRepository;
 import ru.dreadblade.czarbank.repository.security.BlacklistedAccessTokenRepository;
+import ru.dreadblade.czarbank.repository.security.RefreshTokenSessionRepository;
 
 import java.util.function.Predicate;
 
@@ -47,11 +46,17 @@ public class AuthenticationService {
 
         Object principal = authentication.getPrincipal();
 
-        if (principal instanceof User) {
-            return (User) principal;
+        if (!(principal instanceof User)) {
+            throw new IllegalStateException();
         }
 
-        throw new CzarBankException(ExceptionMessage.USER_NOT_FOUND);
+        User user = (User) principal;
+
+        if (!user.isEmailVerified()) {
+            throw new CzarBankSecurityException(ExceptionMessage.EMAIL_VERIFICATION_REQUIRED);
+        }
+
+        return user;
     }
 
     public void logout(String accessToken, String refreshToken) {

--- a/src/main/java/ru/dreadblade/czarbank/service/MailService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/MailService.java
@@ -1,0 +1,26 @@
+package ru.dreadblade.czarbank.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MailService {
+    private final MailSender mailSender;
+
+    @Autowired
+    public MailService(MailSender mailSender) {
+        this.mailSender = mailSender;
+    }
+
+    public void sendMail(String recipientEmailAddress, String subject, String content) {
+        SimpleMailMessage mailMessage = new SimpleMailMessage();
+
+        mailMessage.setTo(recipientEmailAddress);
+        mailMessage.setSubject(subject);
+        mailMessage.setText(content);
+
+        mailSender.send(mailMessage);
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/service/security/AccountManagementService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/security/AccountManagementService.java
@@ -1,0 +1,35 @@
+package ru.dreadblade.czarbank.service.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ru.dreadblade.czarbank.domain.security.EmailVerificationToken;
+import ru.dreadblade.czarbank.domain.security.User;
+import ru.dreadblade.czarbank.exception.CzarBankSecurityException;
+import ru.dreadblade.czarbank.exception.ExceptionMessage;
+import ru.dreadblade.czarbank.repository.security.UserRepository;
+
+@Service
+public class AccountManagementService {
+    private final UserRepository userRepository;
+    private final EmailVerificationTokenService emailVerificationTokenService;
+
+    @Autowired
+    public AccountManagementService(UserRepository userRepository, EmailVerificationTokenService emailVerificationTokenService) {
+        this.userRepository = userRepository;
+        this.emailVerificationTokenService = emailVerificationTokenService;
+    }
+
+    public void verifyEmail(String token) {
+        EmailVerificationToken emailVerificationToken = emailVerificationTokenService.findByEmailVerificationToken(token);
+
+        User userToVerify = emailVerificationToken.getUser();
+
+        if (userToVerify.isEmailVerified()) {
+            throw new CzarBankSecurityException(ExceptionMessage.EMAIL_ADDRESS_ALREADY_VERIFIED);
+        }
+
+        userToVerify.setEmailVerified(true);
+
+        userRepository.save(userToVerify);
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/service/security/EmailVerificationTokenService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/security/EmailVerificationTokenService.java
@@ -1,0 +1,45 @@
+package ru.dreadblade.czarbank.service.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import ru.dreadblade.czarbank.domain.security.User;
+import ru.dreadblade.czarbank.domain.security.EmailVerificationToken;
+import ru.dreadblade.czarbank.exception.CzarBankSecurityException;
+import ru.dreadblade.czarbank.exception.ExceptionMessage;
+import ru.dreadblade.czarbank.repository.security.EmailVerificationTokenRepository;
+
+import java.util.UUID;
+
+@Service
+public class EmailVerificationTokenService {
+    private final EmailVerificationTokenRepository emailVerificationTokenRepository;
+
+    @Autowired
+    public EmailVerificationTokenService(EmailVerificationTokenRepository emailVerificationTokenRepository) {
+        this.emailVerificationTokenRepository = emailVerificationTokenRepository;
+    }
+
+    public EmailVerificationToken generateVerificationToken(User user) {
+        EmailVerificationToken emailVerificationToken = EmailVerificationToken.builder()
+                .emailVerificationToken(generateEmailVerificationToken())
+                .user(user)
+                .build();
+
+        return emailVerificationTokenRepository.save(emailVerificationToken);
+    }
+
+    private String generateEmailVerificationToken() {
+        String emailVerificationToken = UUID.randomUUID().toString();
+
+        while (emailVerificationTokenRepository.existsByEmailVerificationToken(emailVerificationToken)) {
+            emailVerificationToken = UUID.randomUUID().toString();
+        }
+
+        return emailVerificationToken;
+    }
+
+    public EmailVerificationToken findByEmailVerificationToken(String emailVerificationToken) {
+        return emailVerificationTokenRepository.findByEmailVerificationToken(emailVerificationToken)
+                .orElseThrow(() -> new CzarBankSecurityException(ExceptionMessage.INVALID_EMAIL_VERIFICATION_TOKEN));
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/service/security/UserService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/security/UserService.java
@@ -78,21 +78,17 @@ public class UserService {
 
         EmailVerificationToken emailVerificationToken = emailVerificationTokenService.generateVerificationToken(user);
 
+        String emailSubject = "Email verification";
         String emailVerificationUrl = ServletUriComponentsBuilder
                 .fromCurrentRequestUri()
                 .replacePath("/api/account-management/verify-email/")
                 .toUriString() + emailVerificationToken.getEmailVerificationToken();
 
-        String messageContent = new StringBuilder()
-                .append("Hello, ")
-                .append(user.getUsername())
-                .append("!\nTo verify your account, please, follow the link below:\n")
-                .append(emailVerificationUrl)
-                .append("\nIf you have any questions, please, let us know\nContact us: support@czarbank.org")
-                .toString();
+        String emailMessageContent = "Hello, " + user.getUsername() +
+                "!\nTo verify your account, please, follow the link below:\n" + emailVerificationUrl +
+                "\nIf you have any questions, please, let us know\nContact us: support@czarbank.org";
 
-
-        mailService.sendMail(user.getEmail(), "New account", messageContent);
+        mailService.sendMail(user.getEmail(), emailSubject, emailMessageContent);
 
         return user;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,3 +35,5 @@ czar-bank:
     refresh-token:
       expiration-seconds: 604800
       limit-per-user: 5
+    email-verification-token:
+      expiration-seconds: 86400

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,19 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
+  mail:
+    host: 'smtp.gmail.com'
+    username: 'email@gmail.com'
+    password: 'password'
+    port: 465
+    protocol: 'smtps'
+    properties:
+      smtps:
+        auth: 'true'
+        starttls:
+          enable: 'true'
+        timeout: 5000
+
 
 czar-bank:
   currency:

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/AccountManagementIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/AccountManagementIntegrationTest.java
@@ -1,0 +1,152 @@
+package ru.dreadblade.czarbank.api.controller;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+import ru.dreadblade.czarbank.api.model.request.security.UserRequestDTO;
+import ru.dreadblade.czarbank.domain.security.EmailVerificationToken;
+import ru.dreadblade.czarbank.domain.security.User;
+import ru.dreadblade.czarbank.exception.ExceptionMessage;
+import ru.dreadblade.czarbank.repository.security.EmailVerificationTokenRepository;
+import ru.dreadblade.czarbank.repository.security.UserRepository;
+import ru.dreadblade.czarbank.service.security.EmailVerificationTokenService;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest(properties = {
+        "czar-bank.security.access-token.expiration-seconds=5",
+        "czar-bank.security.refresh-token.expiration-seconds=5",
+})
+@DisplayName("Account Management Integration Tests")
+@Sql(value = "/user/users-insertion.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(value = "/user/users-deletion.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+public class AccountManagementIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    EmailVerificationTokenService emailVerificationTokenService;
+
+    @Autowired
+    EmailVerificationTokenRepository emailVerificationTokenRepository;
+
+    @MockBean
+    MailSender mailSender;
+
+    private static final String VERIFY_EMAIL_API_URL = "/api/account-management/verify-email";
+
+    private static final String USERS_API_URL = "/api/users";
+
+    @Nested
+    @DisplayName("verifyEmail() Tests")
+    class VerifyEmailTests {
+
+        @Test
+        @Transactional
+        void verifyEmail_isSuccessful() throws Exception {
+            UserRequestDTO requestDTO = UserRequestDTO.builder()
+                    .username("boyarin")
+                    .email("boyarin@czarbank.org")
+                    .password("password")
+                    .build();
+
+            mockMvc.perform(post(USERS_API_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDTO)))
+                    .andExpect(status().isCreated());
+
+            Mockito.verify(mailSender, Mockito.times(1)).send(Mockito.any(SimpleMailMessage.class));
+
+            User createdUser = userRepository.findByUsername(requestDTO.getUsername()).orElseThrow();
+            Assertions.assertThat(createdUser.isEmailVerified()).isFalse();
+
+            var emailVerificationsTokenForUser = emailVerificationTokenRepository.findAllByUser(createdUser);
+            Assertions.assertThat(emailVerificationsTokenForUser).hasSize(1);
+
+            EmailVerificationToken emailVerificationToken = emailVerificationsTokenForUser.get(0);
+
+            mockMvc.perform(get(VERIFY_EMAIL_API_URL + "/" + emailVerificationToken.getEmailVerificationToken()))
+                    .andExpect(status().isOk());
+
+            Assertions.assertThat(createdUser.isEmailVerified()).isTrue();
+        }
+
+        @Test
+        @Transactional
+        void verifyEmail_emailVerificationToken_isInvalid_isFailed() throws Exception {
+            UserRequestDTO requestDTO = UserRequestDTO.builder()
+                    .username("boyarin")
+                    .email("boyarin@czarbank.org")
+                    .password("password")
+                    .build();
+
+            mockMvc.perform(post(USERS_API_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDTO)))
+                    .andExpect(status().isCreated());
+
+            Mockito.verify(mailSender, Mockito.times(1)).send(Mockito.any(SimpleMailMessage.class));
+
+            User createdUser = userRepository.findByUsername(requestDTO.getUsername()).orElseThrow();
+            Assertions.assertThat(createdUser.isEmailVerified()).isFalse();
+
+            var emailVerificationsTokenForUser = emailVerificationTokenRepository.findAllByUser(createdUser);
+            Assertions.assertThat(emailVerificationsTokenForUser).hasSize(1);
+
+            String emailVerificationToken = "aRandomStaffThatCantBeValid";
+
+            mockMvc.perform(get(VERIFY_EMAIL_API_URL + "/" + emailVerificationToken))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(ExceptionMessage.INVALID_EMAIL_VERIFICATION_TOKEN.getMessage()));
+
+            Assertions.assertThat(createdUser.isEmailVerified()).isFalse();
+        }
+
+        @Test
+        @Transactional
+        void verifyEmail_userHasAlreadyVerifiedTheirEmail_isFailed() throws Exception {
+            UserRequestDTO requestDTO = UserRequestDTO.builder()
+                    .username("boyarin")
+                    .email("boyarin@czarbank.org")
+                    .password("password")
+                    .build();
+
+            mockMvc.perform(post(USERS_API_URL)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(requestDTO)))
+                    .andExpect(status().isCreated());
+
+            Mockito.verify(mailSender, Mockito.times(1)).send(Mockito.any(SimpleMailMessage.class));
+
+            User createdUser = userRepository.findByUsername(requestDTO.getUsername()).orElseThrow();
+            Assertions.assertThat(createdUser.isEmailVerified()).isFalse();
+
+            createdUser.setEmailVerified(true);
+
+            Assertions.assertThat(createdUser.isEmailVerified()).isTrue();
+
+            var emailVerificationsTokenForUser = emailVerificationTokenRepository.findAllByUser(createdUser);
+            Assertions.assertThat(emailVerificationsTokenForUser).hasSize(1);
+
+            EmailVerificationToken emailVerificationToken = emailVerificationsTokenForUser.get(0);
+
+            mockMvc.perform(get(VERIFY_EMAIL_API_URL + "/" + emailVerificationToken.getEmailVerificationToken()))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value(ExceptionMessage.EMAIL_ADDRESS_ALREADY_VERIFIED.getMessage()));
+
+        }
+    }
+}

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/UserIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/UserIntegrationTest.java
@@ -4,9 +4,13 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.mail.MailSender;
+import org.springframework.mail.SimpleMailMessage;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.jdbc.Sql;
@@ -47,6 +51,9 @@ public class UserIntegrationTest extends BaseIntegrationTest {
 
     @Autowired
     RoleMapper roleMapper;
+
+    @MockBean
+    MailSender mailSender;
 
     private static final String USERS_API_URL = "/api/users";
 
@@ -171,6 +178,8 @@ public class UserIntegrationTest extends BaseIntegrationTest {
                     .content(objectMapper.writeValueAsString(requestDTO)))
                     .andExpect(status().isCreated());
 
+            Mockito.verify(mailSender, Mockito.times(1)).send(Mockito.any(SimpleMailMessage.class));
+
             User createdUser = userRepository.findByUsername(requestDTO.getUsername()).orElseThrow();
 
             Assertions.assertThat(createdUser.getEmail()).isEqualTo(createdUser.getEmail());
@@ -192,6 +201,8 @@ public class UserIntegrationTest extends BaseIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDTO)))
                     .andExpect(status().isCreated());
+
+            Mockito.verify(mailSender, Mockito.times(1)).send(Mockito.any(SimpleMailMessage.class));
 
             User createdUser = userRepository.findByUsername(requestDTO.getUsername()).orElseThrow();
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,6 +4,18 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+  mail:
+    host: 'smtp.gmail.com'
+    username: 'email@gmail.com'
+    password: 'password'
+    port: 465
+    protocol: 'smtps'
+    properties:
+      smtps:
+        auth: 'true'
+        starttls:
+          enable: 'true'
+        timeout: 5000
 
 czar-bank:
   currency:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -32,3 +32,5 @@ czar-bank:
     refresh-token:
       expiration-seconds: 604800
       limit-per-user: 5
+    email-verification-token:
+      expiration-seconds: 86400

--- a/src/test/resources/user/users-deletion.sql
+++ b/src/test/resources/user/users-deletion.sql
@@ -1,5 +1,6 @@
 delete from user_role;
 delete from refresh_token_session;
+delete from email_verification_token;
 delete from users;
 delete from role_permission;
 delete from role;

--- a/src/test/resources/user/users-insertion.sql
+++ b/src/test/resources/user/users-insertion.sql
@@ -49,12 +49,12 @@ values (23, 5), (23, 6), (23, 7), (23, 8),
        (23, 9), (23, 10), (23, 11), (23, 12),
        (23, 19);
 
-insert into users (id, user_id, username, email, password, is_account_expired, is_account_locked, is_credentials_expired, is_enabled) values
-(25, '1234567890', 'admin', 'admin@czarbank.org', 'password', false, false, false, true),
-(26, '0192837465', 'employee', 'employee@czarbank.org', 'password', false, false, false, true),
-(27, '6574832910', 'client', 'client@czarbank.org', 'password', false, false, false, true),
-(28, '6574832910', 'alekseev', 'alekseev@czarbank.org', 'password', false, false, false, true),
-(29, '6574832910', 'markov', 'markov@czarbank.org', 'password', false, false, false, true);
+insert into users (id, user_id, username, email, password, is_email_verified, is_account_expired, is_account_locked, is_credentials_expired, is_enabled) values
+(25, '1234567890', 'admin', 'admin@czarbank.org', 'password', true, false, false, false, true),
+(26, '0192837465', 'employee', 'employee@czarbank.org', 'password', true, false, false, false, true),
+(27, '6574832910', 'client', 'client@czarbank.org', 'password', true, false, false, false, true),
+(28, '6574832910', 'alekseev', 'alekseev@czarbank.org', 'password', true, false, false, false, true),
+(29, '6574832910', 'markov', 'markov@czarbank.org', 'password', true, false, false, false, true);
 
 insert into user_role (user_id, role_id)
 values (25, 22),


### PR DESCRIPTION
Added new API endpoint: `/api/account-management/verify-email/{token}`

To log in, you need to verify your email address. This can be done by following the link from the email sent to the email address provided by the user when creating the account. 

The link has a lifetime, after which it will expire. If you click on a link that has already expired, you will receive a new email to the same email address.