### PR TITLE
NoOp email sender & Freemarker template-based emails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+				<version>${parent.version}</version>
 				<configuration>
 					<excludes>
 						<exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-freemarker</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>com.auth0</groupId>

--- a/src/main/java/ru/dreadblade/czarbank/config/CzarBankConfiguration.java
+++ b/src/main/java/ru/dreadblade/czarbank/config/CzarBankConfiguration.java
@@ -1,9 +1,14 @@
 package ru.dreadblade.czarbank.config;
 
+import freemarker.cache.ClassTemplateLoader;
+import freemarker.cache.TemplateLoader;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
+
+import static freemarker.template.Configuration.VERSION_2_3_31;
 
 @Configuration
 @EnableScheduling
@@ -11,5 +16,18 @@ public class CzarBankConfiguration {
     @Bean
     public RestTemplate restTemplate() {
         return new RestTemplate();
+    }
+
+    @Bean
+    public FreeMarkerConfigurer freeMarkerClassLoaderConfig() {
+        freemarker.template.Configuration configuration = new freemarker.template.Configuration(VERSION_2_3_31);
+
+        TemplateLoader templateLoader = new ClassTemplateLoader(this.getClass(), "/templates/email");
+        configuration.setTemplateLoader(templateLoader);
+
+        FreeMarkerConfigurer freeMarkerConfigurer = new FreeMarkerConfigurer();
+        freeMarkerConfigurer.setConfiguration(configuration);
+
+        return freeMarkerConfigurer;
     }
 }

--- a/src/main/java/ru/dreadblade/czarbank/service/email/MailService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/email/MailService.java
@@ -1,5 +1,7 @@
 package ru.dreadblade.czarbank.service.email;
 
+import javax.mail.MessagingException;
+
 public interface MailService {
-    void sendMail(String recipientEmailAddress, String subject, String content);
+    void sendHtmlMail(String recipientEmailAddress, String subject, String htmlContent) throws MessagingException;
 }

--- a/src/main/java/ru/dreadblade/czarbank/service/email/MailService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/email/MailService.java
@@ -1,0 +1,5 @@
+package ru.dreadblade.czarbank.service.email;
+
+public interface MailService {
+    void sendMail(String recipientEmailAddress, String subject, String content);
+}

--- a/src/main/java/ru/dreadblade/czarbank/service/email/NoOpMailService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/email/NoOpMailService.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 @ConditionalOnMissingBean(SmtpMailService.class)
 public class NoOpMailService implements MailService {
     @Override
-    public void sendMail(String recipientEmailAddress, String subject, String content) {
-        log.info("Email sent to {}:\n{}\n{}", recipientEmailAddress, subject, content);
+    public void sendHtmlMail(String recipientEmailAddress, String subject, String htmlContent) {
+        log.info("Email sent to {}:\n{}\n{}", recipientEmailAddress, subject, htmlContent);
     }
 }

--- a/src/main/java/ru/dreadblade/czarbank/service/email/NoOpMailService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/email/NoOpMailService.java
@@ -1,0 +1,15 @@
+package ru.dreadblade.czarbank.service.email;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@ConditionalOnMissingBean(SmtpMailService.class)
+public class NoOpMailService implements MailService {
+    @Override
+    public void sendMail(String recipientEmailAddress, String subject, String content) {
+        log.info("Email sent to {}:\n{}\n{}", recipientEmailAddress, subject, content);
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/service/email/SmtpMailService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/email/SmtpMailService.java
@@ -1,19 +1,18 @@
-package ru.dreadblade.czarbank.service;
+package ru.dreadblade.czarbank.service.email;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
 import org.springframework.mail.MailSender;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.stereotype.Service;
 
 @Service
-public class MailService {
+@Profile("smtp")
+@RequiredArgsConstructor
+public class SmtpMailService implements MailService {
     private final MailSender mailSender;
 
-    @Autowired
-    public MailService(MailSender mailSender) {
-        this.mailSender = mailSender;
-    }
-
+    @Override
     public void sendMail(String recipientEmailAddress, String subject, String content) {
         SimpleMailMessage mailMessage = new SimpleMailMessage();
 

--- a/src/main/java/ru/dreadblade/czarbank/service/email/SmtpMailService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/email/SmtpMailService.java
@@ -2,24 +2,28 @@ package ru.dreadblade.czarbank.service.email;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
-import org.springframework.mail.MailSender;
-import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
 
 @Service
 @Profile("smtp")
 @RequiredArgsConstructor
 public class SmtpMailService implements MailService {
-    private final MailSender mailSender;
+    private final JavaMailSender javaMailSender;
 
     @Override
-    public void sendMail(String recipientEmailAddress, String subject, String content) {
-        SimpleMailMessage mailMessage = new SimpleMailMessage();
+    public void sendHtmlMail(String recipientEmailAddress, String subject, String htmlContent) throws MessagingException {
+        MimeMessage message = javaMailSender.createMimeMessage();
+        MimeMessageHelper helper = new MimeMessageHelper(message, true, "UTF-8");
 
-        mailMessage.setTo(recipientEmailAddress);
-        mailMessage.setSubject(subject);
-        mailMessage.setText(content);
+        helper.setTo(recipientEmailAddress);
+        helper.setSubject(subject);
+        helper.setText(htmlContent, true);
 
-        mailSender.send(mailMessage);
+        javaMailSender.send(message);
     }
 }

--- a/src/main/java/ru/dreadblade/czarbank/service/freemarker/FreemarkerTemplateService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/freemarker/FreemarkerTemplateService.java
@@ -1,0 +1,23 @@
+package ru.dreadblade.czarbank.service.freemarker;
+
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
+import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
+
+import java.io.IOException;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class FreemarkerTemplateService {
+    private final FreeMarkerConfigurer freeMarkerConfigurer;
+
+    public String getProcessedFreemarkerTemplate(String name, Map<String, Object> model) throws IOException, TemplateException {
+        Template freemarkerTemplate = freeMarkerConfigurer.getConfiguration().getTemplate(name);
+
+        return FreeMarkerTemplateUtils.processTemplateIntoString(freemarkerTemplate, model);
+    }
+}

--- a/src/main/java/ru/dreadblade/czarbank/service/security/AccountManagementService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/security/AccountManagementService.java
@@ -9,7 +9,7 @@ import ru.dreadblade.czarbank.domain.security.User;
 import ru.dreadblade.czarbank.exception.CzarBankSecurityException;
 import ru.dreadblade.czarbank.exception.ExceptionMessage;
 import ru.dreadblade.czarbank.repository.security.UserRepository;
-import ru.dreadblade.czarbank.service.MailService;
+import ru.dreadblade.czarbank.service.email.MailService;
 
 import java.time.Instant;
 

--- a/src/main/java/ru/dreadblade/czarbank/service/security/AccountManagementService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/security/AccountManagementService.java
@@ -1,6 +1,7 @@
 package ru.dreadblade.czarbank.service.security;
 
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -10,19 +11,28 @@ import ru.dreadblade.czarbank.exception.CzarBankSecurityException;
 import ru.dreadblade.czarbank.exception.ExceptionMessage;
 import ru.dreadblade.czarbank.repository.security.UserRepository;
 import ru.dreadblade.czarbank.service.email.MailService;
+import ru.dreadblade.czarbank.service.freemarker.FreemarkerTemplateService;
 
 import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 public class AccountManagementService {
+    private static final String VERIFICATION_EMAIL_SUBJECT = "czar-bank account verification";
+    private static final String VERIFICATION_EMAIL_SUPPORT_EMAIL_ADDRESS = "support@czarbank.org";
+    private static final String VERIFICATION_EMAIL_TEMPLATE_FILENAME = "verification-email-message.ftlh";
+
     private final UserRepository userRepository;
     private final EmailVerificationTokenService emailVerificationTokenService;
     private final MailService mailService;
+    private final FreemarkerTemplateService templateService;
 
     @Value("${czar-bank.security.email-verification-token.expiration-seconds:86400}")
     private Long emailVerificationTokenExpirationSeconds;
 
+    @SneakyThrows
     public void verifyEmail(String token) {
         EmailVerificationToken emailVerificationToken = emailVerificationTokenService.findByEmailVerificationToken(token);
 
@@ -40,12 +50,14 @@ public class AccountManagementService {
                     .replacePath("/api/account-management/verify-email/")
                     .toUriString() + emailVerificationToken.getEmailVerificationToken();
 
-            String emailSubject = "Email verification";
-            String emailMessageContent = "Hello, " + userToVerify.getUsername() +
-                    "!\nTo verify your account, please, follow the link below:\n" + emailVerificationUrl +
-                    "\nIf you have any questions, please, let us know\nContact us: support@czarbank.org";
+            Map<String, Object> templateModel = new HashMap<>();
+            templateModel.put("username", userToVerify.getUsername());
+            templateModel.put("emailVerificationUrl", emailVerificationUrl);
+            templateModel.put("supportEmailAddress", VERIFICATION_EMAIL_SUPPORT_EMAIL_ADDRESS);
 
-            mailService.sendMail(userToVerify.getEmail(), emailSubject, emailMessageContent);
+            String emailMessageContent = templateService.getProcessedFreemarkerTemplate(VERIFICATION_EMAIL_TEMPLATE_FILENAME, templateModel);
+
+            mailService.sendHtmlMail(userToVerify.getEmail(), VERIFICATION_EMAIL_SUBJECT, emailMessageContent);
 
             throw new CzarBankSecurityException(ExceptionMessage.EMAIL_VERIFICATION_TOKEN_EXPIRED);
         }

--- a/src/main/java/ru/dreadblade/czarbank/service/security/UserService.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/security/UserService.java
@@ -1,8 +1,8 @@
 package ru.dreadblade.czarbank.service.security;
 
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -13,7 +13,7 @@ import ru.dreadblade.czarbank.exception.CzarBankException;
 import ru.dreadblade.czarbank.exception.ExceptionMessage;
 import ru.dreadblade.czarbank.repository.security.RoleRepository;
 import ru.dreadblade.czarbank.repository.security.UserRepository;
-import ru.dreadblade.czarbank.service.MailService;
+import ru.dreadblade.czarbank.service.email.MailService;
 
 import java.util.Collections;
 import java.util.List;
@@ -22,21 +22,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
+@RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
     private final EmailVerificationTokenService emailVerificationTokenService;
     private final PasswordEncoder passwordEncoder;
     private final MailService mailService;
-
-    @Autowired
-    public UserService(UserRepository userRepository, RoleRepository roleRepository, EmailVerificationTokenService emailVerificationTokenService, PasswordEncoder passwordEncoder, MailService mailService) {
-        this.userRepository = userRepository;
-        this.roleRepository = roleRepository;
-        this.emailVerificationTokenService = emailVerificationTokenService;
-        this.passwordEncoder = passwordEncoder;
-        this.mailService = mailService;
-    }
 
     public List<User> findAll() {
         return userRepository.findAll();

--- a/src/main/java/ru/dreadblade/czarbank/service/task/ScheduledTasks.java
+++ b/src/main/java/ru/dreadblade/czarbank/service/task/ScheduledTasks.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.TimeUnit;
+
 @Component
 @Slf4j
 @RequiredArgsConstructor
@@ -12,7 +14,7 @@ public class ScheduledTasks {
     private final FetchExchangeRatesFromCbrTask fetchExchangeRatesFromCbrTask;
     private final ReleaseBlacklistedAccessTokensTask releaseBlacklistedAccessTokensTask;
 
-    @Scheduled(fixedRateString = "#{${czar-bank.currency.exchange-rate.update-rate-in-millis:3600} * 1000}")
+    @Scheduled(fixedRateString = "#{${czar-bank.currency.exchange-rate.update-rate-seconds:86400}}", timeUnit = TimeUnit.SECONDS)
     public void fetchExchangeRatesFromCbr() {
         if (fetchExchangeRatesFromCbrTask.execute()) {
             log.info("Fetching currency exchange rates from the API of the Central Bank of Russia completed successfully");
@@ -21,7 +23,7 @@ public class ScheduledTasks {
         }
     }
 
-    @Scheduled(fixedRateString = "#{${czar-bank.security.json-web-token.access-token.expiration-seconds:900} * 1000}")
+    @Scheduled(fixedRateString = "#{${czar-bank.security.access-token.expiration-seconds:900}}", timeUnit = TimeUnit.SECONDS)
     public void releaseBlacklistedAccessTokens() {
         if (releaseBlacklistedAccessTokensTask.execute()) {
             log.info("Released blacklisted access tokens");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,34 +1,41 @@
 spring:
+  application:
+    name: 'czar-bank'
   datasource:
-    url: 'jdbc:postgresql://localhost:5432/czar_bank'
-    username: 'username'
-    password: 'password'
+    url: 'jdbc:postgresql://${SPRING_DATASOURCE_HOST}:${SPRING_DATASOURCE_PORT}/${SPRING_DATASOURCE_DATABASE}'
+    username: ${SPRING_DATASOURCE_USERNAME}
+    password: ${SPRING_DATASOURCE_PASSWORD}
   jpa:
     hibernate:
       ddl-auto: validate
-  mail:
-    host: 'smtp.gmail.com'
-    username: 'email@gmail.com'
-    password: 'password'
-    port: 465
-    protocol: 'smtps'
-    properties:
-      smtps:
-        auth: 'true'
-        starttls:
-          enable: 'true'
-        timeout: 5000
+# Required at "smtp" profile
+#  mail:
+#    host: 'smtp.host'
+#    username: ${SPRING_MAIL_USERNAME}
+#    password: ${SPRING_MAIL_PASSWORD}
+#    port: 465
+#    protocol: 'smtps'
+#    test-connection: true
+#    properties:
+#      mail:
+#        smtp:
+#          auth: true
+#          ssl:
+#            enable: true
+#          starttls:
+#            enable: true
+#          timeout: 5000
 
 czar-bank:
   currency:
     exchange-rate:
-      update-rate-in-seconds: 3600
+      update-rate-seconds: 86400
   security:
     access-token:
       issuer: 'Czar Bank'
       audience: 'Czar Bank clients and staff'
       expiration-seconds: 900
-      secret-key: 'czar-bank-secret-key'
+      secret-key: ${CZAR_BANK_ACCESS_TOKEN_SECRET_KEY}
       header:
         prefix: 'Bearer '
     refresh-token:

--- a/src/main/resources/templates/email/verification-email-message.ftlh
+++ b/src/main/resources/templates/email/verification-email-message.ftlh
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body style="font-family: Roboto, sans-serif;">
+<div class="email-wrapper" style="background: #fafafa;">
+    <div class="email-content-wrapper" style="background: #ffffff; margin: 0 auto; max-width: 600px; border: 1px solid rgb(192, 192, 192); border-top: 4px solid #00bfff;">
+        <div class="email-body" style="margin: 8px;">
+            <div class="email-header" style="display: flex; justify-content: center;">
+                <p class="header" style="font-weight: bolder; font-size: 40px;">czar-bank</p>
+            </div>
+            <br>
+            <div class="email-content" style="display: flex; justify-content: center; font-size: 18px;">
+                <div>
+                    <p style="font-size: 18px;">
+                        Hello, ${username},
+                    </p>
+                    <p style="font-size: 18px;">
+                        To verify your account, please, confirm your e-mail address
+                    </p>
+                    <br>
+                    <div class="email-verify-button-wrapper" style="display: flex; justify-content: center;">
+                        <a href="${emailVerificationUrl}" target="_blank">
+                            <button class="email-verify-button" style="border: solid 1px transparent; border-radius: 4px; background-color: #00bfff; color: #fff; font-size: 24px; width: 320px; height: 48px;">
+                                Confirm e-mail address
+                            </button>
+                        </a>
+                    </div>
+                    <br>
+                    <p style="font-size: 18px;">
+                        Or confirm using the link:&nbsp;
+                        <a href="${emailVerificationUrl}" target="_blank">
+                            ${emailVerificationUrl}
+                        </a>
+                    </p>
+                    <br>
+                    <div class="email-support-wrapper" style="display: flex; justify-content: center;">
+                        <div class="email-support" style="display: flex; justify-content: center;">
+                            <div>
+                                <p class="email-support-header" style="display: flex; justify-content: center; font-size: 24pt;">
+                                    Support
+                                </p>
+                                <br>
+                                <div>
+                                    <p class="email-support-content" style="display: flex; justify-content: center; font-size: 18px;">If you have any questions, please, let us know</p>
+                                    <p class="email-support-content" style="display: flex; justify-content: center; font-size: 18px;">Contact us:&nbsp;${supportEmailAddress}</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="email-footer" style="background: #fafafa; display: flex; justify-content: center; padding: 16px; color: rgba(0,0,0,0.3); font-size: 18px;">
+        The source code can be found at&nbsp;<a href="https://github.com/Dreadblade-dev/czar-bank">GitHub</a>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/AccountManagementIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/AccountManagementIntegrationTest.java
@@ -11,15 +11,11 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.mail.MailSender;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.jdbc.Sql;
@@ -79,9 +75,6 @@ public class AccountManagementIntegrationTest extends BaseIntegrationTest {
     @Autowired
     RecoveryCodeRepository recoveryCodeRepository;
 
-    @MockBean
-    MailSender mailSender;
-
     @Autowired
     TotpService totpService;
 
@@ -120,8 +113,6 @@ public class AccountManagementIntegrationTest extends BaseIntegrationTest {
                             .content(objectMapper.writeValueAsString(requestDTO)))
                     .andExpect(status().isCreated());
 
-            Mockito.verify(mailSender, Mockito.times(1)).send(Mockito.any(SimpleMailMessage.class));
-
             User createdUser = userRepository.findByUsername(requestDTO.getUsername()).orElseThrow();
             assertThat(createdUser.isEmailVerified()).isFalse();
 
@@ -150,7 +141,6 @@ public class AccountManagementIntegrationTest extends BaseIntegrationTest {
                             .content(objectMapper.writeValueAsString(requestDTO)))
                     .andExpect(status().isCreated());
 
-            Mockito.verify(mailSender, Mockito.times(1)).send(Mockito.any(SimpleMailMessage.class));
 
             User createdUser = userRepository.findByUsername(requestDTO.getUsername()).orElseThrow();
             assertThat(createdUser.isEmailVerified()).isFalse();
@@ -167,8 +157,6 @@ public class AccountManagementIntegrationTest extends BaseIntegrationTest {
                     .andExpect(jsonPath("$.message").value(ExceptionMessage.EMAIL_VERIFICATION_TOKEN_EXPIRED.getMessage()));
 
             assertThat(createdUser.isEmailVerified()).isFalse();
-
-            Mockito.verify(mailSender, Mockito.times(2)).send(Mockito.any(SimpleMailMessage.class));
 
             emailVerificationTokensForUser = emailVerificationTokenRepository.findAllByUser(createdUser);
             assertThat(emailVerificationTokensForUser).hasSize(2);
@@ -194,8 +182,6 @@ public class AccountManagementIntegrationTest extends BaseIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDTO)))
                     .andExpect(status().isCreated());
-
-            Mockito.verify(mailSender, Mockito.times(1)).send(Mockito.any(SimpleMailMessage.class));
 
             User createdUser = userRepository.findByUsername(requestDTO.getUsername()).orElseThrow();
             assertThat(createdUser.isEmailVerified()).isFalse();
@@ -225,8 +211,6 @@ public class AccountManagementIntegrationTest extends BaseIntegrationTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(requestDTO)))
                     .andExpect(status().isCreated());
-
-            Mockito.verify(mailSender, Mockito.times(1)).send(Mockito.any(SimpleMailMessage.class));
 
             User createdUser = userRepository.findByUsername(requestDTO.getUsername()).orElseThrow();
             assertThat(createdUser.isEmailVerified()).isFalse();

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/UserIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/UserIntegrationTest.java
@@ -9,16 +9,21 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.mail.MailSender;
-import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.utility.DockerImageName;
 import ru.dreadblade.czarbank.api.mapper.security.RoleMapper;
 import ru.dreadblade.czarbank.api.mapper.security.UserMapper;
 import ru.dreadblade.czarbank.api.model.request.security.UserRequestDTO;
@@ -29,6 +34,7 @@ import ru.dreadblade.czarbank.exception.ExceptionMessage;
 import ru.dreadblade.czarbank.repository.security.RoleRepository;
 import ru.dreadblade.czarbank.repository.security.UserRepository;
 
+import javax.mail.internet.MimeMessage;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -45,6 +51,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Sql(value = "/user/users-insertion.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(value = "/user/users-deletion.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 public class UserIntegrationTest extends BaseIntegrationTest {
+    private static final String USERS_API_URL = "/api/users";
+
     @Autowired
     UserRepository userRepository;
 
@@ -57,10 +65,21 @@ public class UserIntegrationTest extends BaseIntegrationTest {
     @Autowired
     RoleMapper roleMapper;
 
-    @MockBean
-    MailSender mailSender;
+    @SpyBean
+    JavaMailSender javaMailSender;
 
-    private static final String USERS_API_URL = "/api/users";
+    @Container
+    static GenericContainer<?> greenMailContainer = new GenericContainer<>(DockerImageName.parse("greenmail/standalone:1.6.9"))
+            .withCreateContainerCmdModifier(cmd -> cmd.withName("czar-bank-test-greenmail"))
+            .waitingFor(Wait.forLogMessage(".*Starting GreenMail standalone.*", 1))
+            .withEnv("GREENMAIL_OPTS", "-Dgreenmail.setup.test.smtp -Dgreenmail.hostname=0.0.0.0 -Dgreenmail.users=greenmail:password")
+            .withExposedPorts(3025);
+
+    @DynamicPropertySource
+    static void configureMailHost(DynamicPropertyRegistry registry) {
+        registry.add("spring.mail.host", greenMailContainer::getHost);
+        registry.add("spring.mail.port", greenMailContainer::getFirstMappedPort);
+    }
 
     @Nested
     @DisplayName("findAll() Tests")
@@ -204,7 +223,7 @@ public class UserIntegrationTest extends BaseIntegrationTest {
                     .content(objectMapper.writeValueAsString(requestDTO)))
                     .andExpect(status().isCreated());
 
-            Mockito.verify(mailSender, Mockito.times(1)).send(Mockito.any(SimpleMailMessage.class));
+            Mockito.verify(javaMailSender, Mockito.times(1)).send(Mockito.any(MimeMessage.class));
 
             User createdUser = userRepository.findByUsername(requestDTO.getUsername()).orElseThrow();
 
@@ -227,7 +246,7 @@ public class UserIntegrationTest extends BaseIntegrationTest {
                             .content(objectMapper.writeValueAsString(requestDTO)))
                     .andExpect(status().isCreated());
 
-            Mockito.verify(mailSender, Mockito.times(1)).send(Mockito.any(SimpleMailMessage.class));
+            Mockito.verify(javaMailSender, Mockito.times(1)).send(Mockito.any(MimeMessage.class));
 
             User createdUser = userRepository.findByUsername(requestDTO.getUsername()).orElseThrow();
 
@@ -424,7 +443,7 @@ public class UserIntegrationTest extends BaseIntegrationTest {
                         .andExpect(jsonPath("$.status").value(HttpStatus.UNPROCESSABLE_ENTITY.value()))
                         .andExpect(jsonPath("$.error").value(VALIDATION_ERROR))
                         .andExpect(jsonPath("$.errors", hasSize(1)))
-                        .andExpect(jsonPath("$.errors[*].field").value( "email"))
+                        .andExpect(jsonPath("$.errors[*].field").value("email"))
                         .andExpect(jsonPath("$.errors[*].message").value("Invalid email address"))
                         .andExpect(jsonPath("$.message").value(INVALID_REQUEST))
                         .andExpect(jsonPath("$.path").value(USERS_API_URL));

--- a/src/test/java/ru/dreadblade/czarbank/api/controller/UserIntegrationTest.java
+++ b/src/test/java/ru/dreadblade/czarbank/api/controller/UserIntegrationTest.java
@@ -16,6 +16,7 @@ import org.springframework.mail.MailSender;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.transaction.annotation.Transactional;
 import ru.dreadblade.czarbank.api.mapper.security.RoleMapper;
@@ -39,6 +40,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
+@ActiveProfiles("smtp")
 @DisplayName("User Integration Tests")
 @Sql(value = "/user/users-insertion.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 @Sql(value = "/user/users-deletion.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,21 +4,12 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
-# Required on smtp profile
   mail:
     host: 'smtp.host'
-    username: 'username'
+    username: 'greenmail'
     password: 'password'
-    port: 465
-    protocol: 'smtps'
-    properties:
-      smtps:
-        auth: 'true'
-        starttls:
-          enable: 'true'
-        timeout: 5000
-  flyway:
-    enabled: false
+    port: 3025
+    protocol: 'smtp'
 
 czar-bank:
   currency:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -4,9 +4,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create-drop
+# Required on smtp profile
   mail:
-    host: 'smtp.gmail.com'
-    username: 'email@gmail.com'
+    host: 'smtp.host'
+    username: 'username'
     password: 'password'
     port: 465
     protocol: 'smtps'
@@ -22,13 +23,13 @@ spring:
 czar-bank:
   currency:
     exchange-rate:
-      update-rate-in-seconds: 3600
+      update-rate-seconds: 86400
   security:
     access-token:
       issuer: 'Czar Bank'
       audience: 'Czar Bank clients and staff'
       expiration-seconds: 900
-      secret-key: 'czar-bank-secret-key'
+      secret-key: 'czar-bank-secret-key-for-tests'
       header:
         prefix: 'Bearer '
     refresh-token:


### PR DESCRIPTION
Added a NoOpMailService which simply logs emails. Used by default.
Now, in order to use SMTP mail service the Spring need to have an active "smtp" profile and corresponding properties in application.yml

Added a feature to send emails based on Apache Freemarker templates
Testing email using Greenmail in integrations tests (docker container greenmail/standalone via testcontainers)

Improved .yml configuration, sensitive data moved into environment variables
Updated verification email design